### PR TITLE
simplifying animatable trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### BREAKING CHANGES:
+- **Major Simplification: Simplified Animatable Trait**
+  - Reduced from 7 required methods to just 2: `interpolate()` and `magnitude()`
+  - Now leverages standard Rust operator traits (`Add`, `Sub`, `Mul<f32>`, `Default`)
+  - Eliminates custom `zero()`, `epsilon()`, `scale()`, `add()`, `sub()` methods
+  - Single default epsilon (0.01) for consistent behavior
+  - ~70% less boilerplate when implementing custom animatable types
+  
+- `KeyframeAnimation::add_keyframe` now returns a `Result`, not `Self`. Chaining requires `.and_then(...).unwrap()` or error handling. All documentation and guides updated to reflect this.
+
+### Migration Guide:
+For custom `Animatable` implementations:
+```rust
+// Before (Old trait):
+impl Animatable for MyType {
+    fn zero() -> Self { /* implementation */ }
+    fn epsilon() -> f32 { /* implementation */ }  
+    fn magnitude(&self) -> f32 { /* implementation */ }
+    fn scale(&self, factor: f32) -> Self { /* implementation */ }
+    fn add(&self, other: &Self) -> Self { /* implementation */ }
+    fn sub(&self, other: &Self) -> Self { /* implementation */ }
+    fn interpolate(&self, target: &Self, t: f32) -> Self { /* implementation */ }
+}
+
+// After (New simplified trait):
+#[derive(Default)] // Add Default derive
+impl Animatable for MyType {
+    fn interpolate(&self, target: &Self, t: f32) -> Self { /* implementation */ }
+    fn magnitude(&self) -> f32 { /* implementation */ }
+}
+
+// Also implement standard operators:
+impl Add for MyType { /* standard addition */ }
+impl Sub for MyType { /* standard subtraction */ }
+impl Mul<f32> for MyType { /* scalar multiplication */ }
+```
+
+Replace `MyType::zero()` calls with `MyType::default()`.
+
 ### Fixes:
 - Layout not being shown when animating in the case of nested Layouts
 - Nested Layout fully fixed
 ### Changes:
 - Few code refactoring
-- BREAKING: `KeyframeAnimation::add_keyframe` now returns a `Result`, not `Self`. Chaining requires `.and_then(...).unwrap()` or error handling. All documentation and guides updated to reflect this.
+- Simplified epsilon system with single default value (0.01)
+- Updated all built-in types (f32, Transform, Color, PageTransitionAnimation) to use new trait
+- Enhanced documentation with simplified examples
 
 ## [0.3.1] - 2024-02-08
 - Rerelease

--- a/README.md
+++ b/README.md
@@ -146,12 +146,13 @@ scale.animate_sequence(sequence);
 
 ## ✨ Features
 
-- **Cross-Platform Support**: Works on web, desktop, and mobile
-- **Flexible Animation Configuration**
-- **Custom Easing Functions**
-- **Modular Feature Setup**
-- **Simple, Intuitive API**
-- **Page Transitions**
+- **🔧 Simplified Animatable Trait**: Uses standard Rust operators (`+`, `-`, `*`) instead of custom methods
+- **🌍 Cross-Platform Support**: Works on web, desktop, and mobile
+- **⚙️ Flexible Animation Configuration**: Spring physics and tween animations
+- **📊 Custom Easing Functions**: Built-in and custom easing support
+- **🧩 Modular Feature Setup**: Choose only what you need
+- **💡 Simple, Intuitive API**: Easy to learn and use
+- **🎬 Page Transitions**: Smooth route transitions with the `transitions` feature
 
 ## 🛠 Installation
 
@@ -194,6 +195,78 @@ Choose the right feature for your platform:
 - `default`: Web support (if no feature specified)
 
 ## 🚀 Quick Start
+
+## 🎨 Creating Custom Animatable Types
+
+The simplified `Animatable` trait makes it easy to create custom animatable types:
+
+```rust
+use dioxus_motion::prelude::*;
+
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
+struct Point3D {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+// Implement standard Rust operator traits
+impl std::ops::Add for Point3D {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+            z: self.z + other.z,
+        }
+    }
+}
+
+impl std::ops::Sub for Point3D {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+            z: self.z - other.z,
+        }
+    }
+}
+
+impl std::ops::Mul<f32> for Point3D {
+    type Output = Self;
+    fn mul(self, factor: f32) -> Self {
+        Self {
+            x: self.x * factor,
+            y: self.y * factor,
+            z: self.z * factor,
+        }
+    }
+}
+
+// Implement Animatable with just two methods!
+impl Animatable for Point3D {
+    fn interpolate(&self, target: &Self, t: f32) -> Self {
+        *self + (*target - *self) * t
+    }
+    
+    fn magnitude(&self) -> f32 {
+        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
+    }
+}
+
+// Now you can animate 3D points!
+let mut position = use_motion(Point3D::default());
+position.animate_to(
+    Point3D { x: 10.0, y: 5.0, z: -2.0 },
+    AnimationConfig::new(AnimationMode::Spring(Spring::default()))
+);
+```
+
+**Previous vs. New Trait Complexity:**
+- **Before**: 7 required methods (`zero`, `epsilon`, `magnitude`, `scale`, `add`, `sub`, `interpolate`)
+- **After**: 2 required methods (`interpolate`, `magnitude`) + standard Rust operators
+- **Result**: ~70% less boilerplate, more idiomatic Rust code!
 
 ## 🔄 Migration Guide (v0.3.0)
 

--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -1,271 +1,47 @@
-/*! tailwindcss v4.0.0 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.1.11 | MIT License | https://tailwindcss.com */
+@layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
-  :root {
+  :root, :host {
     --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      "Liberation Mono", "Courier New", monospace;
-    --color-red-50: oklch(0.971 0.013 17.38);
-    --color-red-100: oklch(0.936 0.032 17.717);
-    --color-red-200: oklch(0.885 0.062 18.334);
-    --color-red-300: oklch(0.808 0.114 19.571);
-    --color-red-400: oklch(0.704 0.191 22.216);
-    --color-red-500: oklch(0.637 0.237 25.331);
-    --color-red-600: oklch(0.577 0.245 27.325);
-    --color-red-700: oklch(0.505 0.213 27.518);
-    --color-red-800: oklch(0.444 0.177 26.899);
-    --color-red-900: oklch(0.396 0.141 25.723);
-    --color-red-950: oklch(0.258 0.092 26.042);
-    --color-orange-50: oklch(0.98 0.016 73.684);
-    --color-orange-100: oklch(0.954 0.038 75.164);
-    --color-orange-200: oklch(0.901 0.076 70.697);
-    --color-orange-300: oklch(0.837 0.128 66.29);
-    --color-orange-400: oklch(0.75 0.183 55.934);
-    --color-orange-500: oklch(0.705 0.213 47.604);
-    --color-orange-600: oklch(0.646 0.222 41.116);
-    --color-orange-700: oklch(0.553 0.195 38.402);
-    --color-orange-800: oklch(0.47 0.157 37.304);
-    --color-orange-900: oklch(0.408 0.123 38.172);
-    --color-orange-950: oklch(0.266 0.079 36.259);
-    --color-amber-50: oklch(0.987 0.022 95.277);
-    --color-amber-100: oklch(0.962 0.059 95.617);
-    --color-amber-200: oklch(0.924 0.12 95.746);
-    --color-amber-300: oklch(0.879 0.169 91.605);
-    --color-amber-400: oklch(0.828 0.189 84.429);
-    --color-amber-500: oklch(0.769 0.188 70.08);
-    --color-amber-600: oklch(0.666 0.179 58.318);
-    --color-amber-700: oklch(0.555 0.163 48.998);
-    --color-amber-800: oklch(0.473 0.137 46.201);
-    --color-amber-900: oklch(0.414 0.112 45.904);
-    --color-amber-950: oklch(0.279 0.077 45.635);
-    --color-yellow-50: oklch(0.987 0.026 102.212);
-    --color-yellow-100: oklch(0.973 0.071 103.193);
-    --color-yellow-200: oklch(0.945 0.129 101.54);
-    --color-yellow-300: oklch(0.905 0.182 98.111);
-    --color-yellow-400: oklch(0.852 0.199 91.936);
-    --color-yellow-500: oklch(0.795 0.184 86.047);
-    --color-yellow-600: oklch(0.681 0.162 75.834);
-    --color-yellow-700: oklch(0.554 0.135 66.442);
-    --color-yellow-800: oklch(0.476 0.114 61.907);
-    --color-yellow-900: oklch(0.421 0.095 57.708);
-    --color-yellow-950: oklch(0.286 0.066 53.813);
-    --color-lime-50: oklch(0.986 0.031 120.757);
-    --color-lime-100: oklch(0.967 0.067 122.328);
-    --color-lime-200: oklch(0.938 0.127 124.321);
-    --color-lime-300: oklch(0.897 0.196 126.665);
-    --color-lime-400: oklch(0.841 0.238 128.85);
-    --color-lime-500: oklch(0.768 0.233 130.85);
-    --color-lime-600: oklch(0.648 0.2 131.684);
-    --color-lime-700: oklch(0.532 0.157 131.589);
-    --color-lime-800: oklch(0.453 0.124 130.933);
-    --color-lime-900: oklch(0.405 0.101 131.063);
-    --color-lime-950: oklch(0.274 0.072 132.109);
-    --color-green-50: oklch(0.982 0.018 155.826);
-    --color-green-100: oklch(0.962 0.044 156.743);
-    --color-green-200: oklch(0.925 0.084 155.995);
-    --color-green-300: oklch(0.871 0.15 154.449);
-    --color-green-400: oklch(0.792 0.209 151.711);
-    --color-green-500: oklch(0.723 0.219 149.579);
-    --color-green-600: oklch(0.627 0.194 149.214);
-    --color-green-700: oklch(0.527 0.154 150.069);
-    --color-green-800: oklch(0.448 0.119 151.328);
-    --color-green-900: oklch(0.393 0.095 152.535);
-    --color-green-950: oklch(0.266 0.065 152.934);
-    --color-emerald-50: oklch(0.979 0.021 166.113);
-    --color-emerald-100: oklch(0.95 0.052 163.051);
-    --color-emerald-200: oklch(0.905 0.093 164.15);
-    --color-emerald-300: oklch(0.845 0.143 164.978);
-    --color-emerald-400: oklch(0.765 0.177 163.223);
-    --color-emerald-500: oklch(0.696 0.17 162.48);
-    --color-emerald-600: oklch(0.596 0.145 163.225);
-    --color-emerald-700: oklch(0.508 0.118 165.612);
-    --color-emerald-800: oklch(0.432 0.095 166.913);
-    --color-emerald-900: oklch(0.378 0.077 168.94);
-    --color-emerald-950: oklch(0.262 0.051 172.552);
-    --color-teal-50: oklch(0.984 0.014 180.72);
-    --color-teal-100: oklch(0.953 0.051 180.801);
-    --color-teal-200: oklch(0.91 0.096 180.426);
-    --color-teal-300: oklch(0.855 0.138 181.071);
-    --color-teal-400: oklch(0.777 0.152 181.912);
-    --color-teal-500: oklch(0.704 0.14 182.503);
-    --color-teal-600: oklch(0.6 0.118 184.704);
-    --color-teal-700: oklch(0.511 0.096 186.391);
-    --color-teal-800: oklch(0.437 0.078 188.216);
-    --color-teal-900: oklch(0.386 0.063 188.416);
-    --color-teal-950: oklch(0.277 0.046 192.524);
-    --color-cyan-50: oklch(0.984 0.019 200.873);
-    --color-cyan-100: oklch(0.956 0.045 203.388);
-    --color-cyan-200: oklch(0.917 0.08 205.041);
-    --color-cyan-300: oklch(0.865 0.127 207.078);
-    --color-cyan-400: oklch(0.789 0.154 211.53);
-    --color-cyan-500: oklch(0.715 0.143 215.221);
-    --color-cyan-600: oklch(0.609 0.126 221.723);
-    --color-cyan-700: oklch(0.52 0.105 223.128);
-    --color-cyan-800: oklch(0.45 0.085 224.283);
-    --color-cyan-900: oklch(0.398 0.07 227.392);
-    --color-cyan-950: oklch(0.302 0.056 229.695);
-    --color-sky-50: oklch(0.977 0.013 236.62);
-    --color-sky-100: oklch(0.951 0.026 236.824);
-    --color-sky-200: oklch(0.901 0.058 230.902);
-    --color-sky-300: oklch(0.828 0.111 230.318);
-    --color-sky-400: oklch(0.746 0.16 232.661);
-    --color-sky-500: oklch(0.685 0.169 237.323);
-    --color-sky-600: oklch(0.588 0.158 241.966);
-    --color-sky-700: oklch(0.5 0.134 242.749);
-    --color-sky-800: oklch(0.443 0.11 240.79);
-    --color-sky-900: oklch(0.391 0.09 240.876);
-    --color-sky-950: oklch(0.293 0.066 243.157);
-    --color-blue-50: oklch(0.97 0.014 254.604);
-    --color-blue-100: oklch(0.932 0.032 255.585);
-    --color-blue-200: oklch(0.882 0.059 254.128);
-    --color-blue-300: oklch(0.809 0.105 251.813);
-    --color-blue-400: oklch(0.707 0.165 254.624);
-    --color-blue-500: oklch(0.623 0.214 259.815);
-    --color-blue-600: oklch(0.546 0.245 262.881);
-    --color-blue-700: oklch(0.488 0.243 264.376);
-    --color-blue-800: oklch(0.424 0.199 265.638);
-    --color-blue-900: oklch(0.379 0.146 265.522);
-    --color-blue-950: oklch(0.282 0.091 267.935);
-    --color-indigo-50: oklch(0.962 0.018 272.314);
-    --color-indigo-100: oklch(0.93 0.034 272.788);
-    --color-indigo-200: oklch(0.87 0.065 274.039);
-    --color-indigo-300: oklch(0.785 0.115 274.713);
-    --color-indigo-400: oklch(0.673 0.182 276.935);
-    --color-indigo-500: oklch(0.585 0.233 277.117);
-    --color-indigo-600: oklch(0.511 0.262 276.966);
-    --color-indigo-700: oklch(0.457 0.24 277.023);
-    --color-indigo-800: oklch(0.398 0.195 277.366);
-    --color-indigo-900: oklch(0.359 0.144 278.697);
-    --color-indigo-950: oklch(0.257 0.09 281.288);
-    --color-violet-50: oklch(0.969 0.016 293.756);
-    --color-violet-100: oklch(0.943 0.029 294.588);
-    --color-violet-200: oklch(0.894 0.057 293.283);
-    --color-violet-300: oklch(0.811 0.111 293.571);
-    --color-violet-400: oklch(0.702 0.183 293.541);
-    --color-violet-500: oklch(0.606 0.25 292.717);
-    --color-violet-600: oklch(0.541 0.281 293.009);
-    --color-violet-700: oklch(0.491 0.27 292.581);
-    --color-violet-800: oklch(0.432 0.232 292.759);
-    --color-violet-900: oklch(0.38 0.189 293.745);
-    --color-violet-950: oklch(0.283 0.141 291.089);
-    --color-purple-50: oklch(0.977 0.014 308.299);
-    --color-purple-100: oklch(0.946 0.033 307.174);
-    --color-purple-200: oklch(0.902 0.063 306.703);
-    --color-purple-300: oklch(0.827 0.119 306.383);
-    --color-purple-400: oklch(0.714 0.203 305.504);
-    --color-purple-500: oklch(0.627 0.265 303.9);
-    --color-purple-600: oklch(0.558 0.288 302.321);
-    --color-purple-700: oklch(0.496 0.265 301.924);
-    --color-purple-800: oklch(0.438 0.218 303.724);
-    --color-purple-900: oklch(0.381 0.176 304.987);
-    --color-purple-950: oklch(0.291 0.149 302.717);
-    --color-fuchsia-50: oklch(0.977 0.017 320.058);
-    --color-fuchsia-100: oklch(0.952 0.037 318.852);
-    --color-fuchsia-200: oklch(0.903 0.076 319.62);
-    --color-fuchsia-300: oklch(0.833 0.145 321.434);
-    --color-fuchsia-400: oklch(0.74 0.238 322.16);
-    --color-fuchsia-500: oklch(0.667 0.295 322.15);
-    --color-fuchsia-600: oklch(0.591 0.293 322.896);
-    --color-fuchsia-700: oklch(0.518 0.253 323.949);
-    --color-fuchsia-800: oklch(0.452 0.211 324.591);
-    --color-fuchsia-900: oklch(0.401 0.17 325.612);
-    --color-fuchsia-950: oklch(0.293 0.136 325.661);
-    --color-pink-50: oklch(0.971 0.014 343.198);
-    --color-pink-100: oklch(0.948 0.028 342.258);
-    --color-pink-200: oklch(0.899 0.061 343.231);
-    --color-pink-300: oklch(0.823 0.12 346.018);
-    --color-pink-400: oklch(0.718 0.202 349.761);
-    --color-pink-500: oklch(0.656 0.241 354.308);
-    --color-pink-600: oklch(0.592 0.249 0.584);
-    --color-pink-700: oklch(0.525 0.223 3.958);
-    --color-pink-800: oklch(0.459 0.187 3.815);
-    --color-pink-900: oklch(0.408 0.153 2.432);
-    --color-pink-950: oklch(0.284 0.109 3.907);
-    --color-rose-50: oklch(0.969 0.015 12.422);
-    --color-rose-100: oklch(0.941 0.03 12.58);
-    --color-rose-200: oklch(0.892 0.058 10.001);
-    --color-rose-300: oklch(0.81 0.117 11.638);
-    --color-rose-400: oklch(0.712 0.194 13.428);
-    --color-rose-500: oklch(0.645 0.246 16.439);
-    --color-rose-600: oklch(0.586 0.253 17.585);
-    --color-rose-700: oklch(0.514 0.222 16.935);
-    --color-rose-800: oklch(0.455 0.188 13.697);
-    --color-rose-900: oklch(0.41 0.159 10.272);
-    --color-rose-950: oklch(0.271 0.105 12.094);
-    --color-slate-50: oklch(0.984 0.003 247.858);
-    --color-slate-100: oklch(0.968 0.007 247.896);
-    --color-slate-200: oklch(0.929 0.013 255.508);
-    --color-slate-300: oklch(0.869 0.022 252.894);
-    --color-slate-400: oklch(0.704 0.04 256.788);
-    --color-slate-500: oklch(0.554 0.046 257.417);
-    --color-slate-600: oklch(0.446 0.043 257.281);
-    --color-slate-700: oklch(0.372 0.044 257.287);
-    --color-slate-800: oklch(0.279 0.041 260.031);
-    --color-slate-900: oklch(0.208 0.042 265.755);
-    --color-slate-950: oklch(0.129 0.042 264.695);
-    --color-gray-50: oklch(0.985 0.002 247.839);
-    --color-gray-100: oklch(0.967 0.003 264.542);
-    --color-gray-200: oklch(0.928 0.006 264.531);
-    --color-gray-300: oklch(0.872 0.01 258.338);
-    --color-gray-400: oklch(0.707 0.022 261.325);
-    --color-gray-500: oklch(0.551 0.027 264.364);
-    --color-gray-600: oklch(0.446 0.03 256.802);
-    --color-gray-700: oklch(0.373 0.034 259.733);
-    --color-gray-800: oklch(0.278 0.033 256.848);
-    --color-gray-900: oklch(0.21 0.034 264.665);
-    --color-gray-950: oklch(0.13 0.028 261.692);
-    --color-zinc-50: oklch(0.985 0 0);
-    --color-zinc-100: oklch(0.967 0.001 286.375);
-    --color-zinc-200: oklch(0.92 0.004 286.32);
-    --color-zinc-300: oklch(0.871 0.006 286.286);
-    --color-zinc-400: oklch(0.705 0.015 286.067);
-    --color-zinc-500: oklch(0.552 0.016 285.938);
-    --color-zinc-600: oklch(0.442 0.017 285.786);
-    --color-zinc-700: oklch(0.37 0.013 285.805);
-    --color-zinc-800: oklch(0.274 0.006 286.033);
-    --color-zinc-900: oklch(0.21 0.006 285.885);
-    --color-zinc-950: oklch(0.141 0.005 285.823);
-    --color-neutral-50: oklch(0.985 0 0);
-    --color-neutral-100: oklch(0.97 0 0);
-    --color-neutral-200: oklch(0.922 0 0);
-    --color-neutral-300: oklch(0.87 0 0);
-    --color-neutral-400: oklch(0.708 0 0);
-    --color-neutral-500: oklch(0.556 0 0);
-    --color-neutral-600: oklch(0.439 0 0);
-    --color-neutral-700: oklch(0.371 0 0);
-    --color-neutral-800: oklch(0.269 0 0);
-    --color-neutral-900: oklch(0.205 0 0);
-    --color-neutral-950: oklch(0.145 0 0);
-    --color-stone-50: oklch(0.985 0.001 106.423);
-    --color-stone-100: oklch(0.97 0.001 106.424);
-    --color-stone-200: oklch(0.923 0.003 48.717);
-    --color-stone-300: oklch(0.869 0.005 56.366);
-    --color-stone-400: oklch(0.709 0.01 56.259);
-    --color-stone-500: oklch(0.553 0.013 58.071);
-    --color-stone-600: oklch(0.444 0.011 73.639);
-    --color-stone-700: oklch(0.374 0.01 67.558);
-    --color-stone-800: oklch(0.268 0.007 34.298);
-    --color-stone-900: oklch(0.216 0.006 56.043);
-    --color-stone-950: oklch(0.147 0.004 49.25);
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    --color-red-50: oklch(97.1% 0.013 17.38);
+    --color-red-500: oklch(63.7% 0.237 25.331);
+    --color-red-600: oklch(57.7% 0.245 27.325);
+    --color-orange-400: oklch(75% 0.183 55.934);
+    --color-orange-500: oklch(70.5% 0.213 47.604);
+    --color-yellow-400: oklch(85.2% 0.199 91.936);
+    --color-yellow-500: oklch(79.5% 0.184 86.047);
+    --color-green-300: oklch(87.1% 0.15 154.449);
+    --color-green-400: oklch(79.2% 0.209 151.711);
+    --color-green-500: oklch(72.3% 0.219 149.579);
+    --color-green-600: oklch(62.7% 0.194 149.214);
+    --color-emerald-400: oklch(76.5% 0.177 163.223);
+    --color-cyan-400: oklch(78.9% 0.154 211.53);
+    --color-blue-200: oklch(88.2% 0.059 254.128);
+    --color-blue-300: oklch(80.9% 0.105 251.813);
+    --color-blue-400: oklch(70.7% 0.165 254.624);
+    --color-blue-500: oklch(62.3% 0.214 259.815);
+    --color-blue-600: oklch(54.6% 0.245 262.881);
+    --color-blue-900: oklch(37.9% 0.146 265.522);
+    --color-indigo-600: oklch(51.1% 0.262 276.966);
+    --color-purple-400: oklch(71.4% 0.203 305.504);
+    --color-purple-500: oklch(62.7% 0.265 303.9);
+    --color-purple-600: oklch(55.8% 0.288 302.321);
+    --color-pink-500: oklch(65.6% 0.241 354.308);
+    --color-pink-600: oklch(59.2% 0.249 0.584);
+    --color-gray-100: oklch(96.7% 0.003 264.542);
+    --color-gray-200: oklch(92.8% 0.006 264.531);
+    --color-gray-500: oklch(55.1% 0.027 264.364);
+    --color-gray-600: oklch(44.6% 0.03 256.802);
+    --color-gray-800: oklch(27.8% 0.033 256.848);
+    --color-gray-900: oklch(21% 0.034 264.665);
+    --color-gray-950: oklch(13% 0.028 261.692);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
-    --breakpoint-sm: 40rem;
-    --breakpoint-md: 48rem;
-    --breakpoint-lg: 64rem;
-    --breakpoint-xl: 80rem;
-    --breakpoint-2xl: 96rem;
-    --container-3xs: 16rem;
-    --container-2xs: 18rem;
-    --container-xs: 20rem;
-    --container-sm: 24rem;
-    --container-md: 28rem;
-    --container-lg: 32rem;
-    --container-xl: 36rem;
-    --container-2xl: 42rem;
-    --container-3xl: 48rem;
     --container-4xl: 56rem;
     --container-5xl: 64rem;
     --container-6xl: 72rem;
@@ -274,8 +50,6 @@
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
-    --text-base: 1rem;
-    --text-base--line-height: calc(1.5 / 1);
     --text-lg: 1.125rem;
     --text-lg--line-height: calc(1.75 / 1.125);
     --text-xl: 1.25rem;
@@ -290,118 +64,43 @@
     --text-5xl--line-height: 1;
     --text-6xl: 3.75rem;
     --text-6xl--line-height: 1;
-    --text-7xl: 4.5rem;
-    --text-7xl--line-height: 1;
-    --text-8xl: 6rem;
-    --text-8xl--line-height: 1;
-    --text-9xl: 8rem;
-    --text-9xl--line-height: 1;
-    --font-weight-thin: 100;
-    --font-weight-extralight: 200;
-    --font-weight-light: 300;
-    --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
-    --font-weight-extrabold: 800;
-    --font-weight-black: 900;
-    --tracking-tighter: -0.05em;
-    --tracking-tight: -0.025em;
-    --tracking-normal: 0em;
     --tracking-wide: 0.025em;
     --tracking-wider: 0.05em;
-    --tracking-widest: 0.1em;
-    --leading-tight: 1.25;
-    --leading-snug: 1.375;
-    --leading-normal: 1.5;
     --leading-relaxed: 1.625;
-    --leading-loose: 2;
-    --radius-xs: 0.125rem;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;
     --radius-2xl: 1rem;
-    --radius-3xl: 1.5rem;
-    --radius-4xl: 2rem;
-    --shadow-2xs: 0 1px rgb(0 0 0 / 0.05);
-    --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-    --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1),
-      0 8px 10px -6px rgb(0 0 0 / 0.1);
-    --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
-    --inset-shadow-2xs: inset 0 1px rgb(0 0 0 / 0.05);
-    --inset-shadow-xs: inset 0 1px 1px rgb(0 0 0 / 0.05);
-    --inset-shadow-sm: inset 0 2px 4px rgb(0 0 0 / 0.05);
-    --drop-shadow-xs: 0 1px 1px rgb(0 0 0 / 0.05);
-    --drop-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.15);
-    --drop-shadow-md: 0 3px 3px rgb(0 0 0 / 0.12);
-    --drop-shadow-lg: 0 4px 4px rgb(0 0 0 / 0.15);
-    --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
-    --drop-shadow-2xl: 0 25px 25px rgb(0 0 0 / 0.15);
-    --ease-in: cubic-bezier(0.4, 0, 1, 1);
     --ease-out: cubic-bezier(0, 0, 0.2, 1);
-    --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
-    --animate-spin: spin 1s linear infinite;
     --animate-ping: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
     --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-    --animate-bounce: bounce 1s infinite;
     --blur-xs: 4px;
     --blur-sm: 8px;
     --blur-md: 12px;
     --blur-lg: 16px;
     --blur-xl: 24px;
-    --blur-2xl: 40px;
     --blur-3xl: 64px;
-    --perspective-dramatic: 100px;
-    --perspective-near: 300px;
-    --perspective-normal: 500px;
-    --perspective-midrange: 800px;
-    --perspective-distant: 1200px;
-    --aspect-video: 16 / 9;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
-    --default-font-feature-settings: var(--font-sans--font-feature-settings);
-    --default-font-variation-settings: var(
-      --font-sans--font-variation-settings
-    );
     --default-mono-font-family: var(--font-mono);
-    --default-mono-font-feature-settings: var(
-      --font-mono--font-feature-settings
-    );
-    --default-mono-font-variation-settings: var(
-      --font-mono--font-variation-settings
-    );
     --font-display: 'JetBrains Mono', monospace;
-    --font-body: 'Inter', sans-serif;
-    --color-background: oklch(0.04 0 0);
-    --color-background-light: oklch(1 0 0);
     --color-dark-50: oklch(0.1 0 0);
     --color-dark-100: oklch(0.15 0 0);
     --color-dark-200: oklch(0.2 0 0);
     --color-dark-300: oklch(0.25 0 0);
-    --color-dark-400: oklch(0.3 0 0);
     --color-light-50: oklch(0.98 0 0);
     --color-light-100: oklch(0.95 0 0);
-    --color-light-200: oklch(0.9 0 0);
-    --color-light-300: oklch(0.85 0 0);
-    --color-light-400: oklch(0.8 0 0);
     --color-primary: oklch(0.75 0.15 30);
     --color-primary-light: oklch(0.8 0.15 30);
-    --color-primary-dark: oklch(0.7 0.15 30);
     --color-primary-hover: oklch(0.85 0.15 30);
     --color-secondary: oklch(0.65 0.02 30);
-    --color-secondary-light: oklch(0.9 0.02 30);
-    --color-secondary-dark: oklch(0.35 0.02 30);
-    --color-accent-rust: oklch(0.75 0.15 30);
-    --color-accent-rust-hover: oklch(0.85 0.15 30);
     --color-surface: oklch(0.25 0 0);
     --color-surface-light: oklch(0.35 0 0);
-    --color-surface-dark: oklch(0.15 0 0);
-    --color-surface-hover: oklch(0.15 0 0 / 0.7);
     --color-text-primary: oklch(1 0 0);
     --color-text-secondary: oklch(0.85 0 0);
     --color-text-muted: oklch(0.65 0 0);
@@ -411,13 +110,6 @@
     --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
     --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
     --ease-snappy: cubic-bezier(0.2, 0, 0, 1);
-    --transition-fast: 150ms var(--ease-snappy);
-    --transition-medium: 300ms var(--ease-smooth);
-    --transition-spring: 500ms var(--ease-spring);
-    --shadow-neumorphic: 20px 20px 60px #d9d9d9, -20px -20px 60px #ffffff,
-    0 4px 6px -1px rgba(255, 255, 255, 0.1),
-    0 2px 4px -1px rgba(255, 255, 255, 0.06),
-    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
 }
 @layer base {
@@ -431,13 +123,10 @@
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
-    font-family: var( --default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" );
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
     font-feature-settings: var(--default-font-feature-settings, normal);
-    font-variation-settings: var( --default-font-variation-settings, normal );
+    font-variation-settings: var(--default-font-variation-settings, normal);
     -webkit-tap-highlight-color: transparent;
-  }
-  body {
-    line-height: inherit;
   }
   hr {
     height: 0;
@@ -461,9 +150,9 @@
     font-weight: bolder;
   }
   code, kbd, samp, pre {
-    font-family: var( --default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace );
-    font-feature-settings: var( --default-mono-font-feature-settings, normal );
-    font-variation-settings: var( --default-mono-font-variation-settings, normal );
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
     font-size: 1em;
   }
   small {
@@ -527,7 +216,14 @@
   }
   ::placeholder {
     opacity: 1;
-    color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
   }
   textarea {
     resize: vertical;
@@ -859,26 +555,26 @@
   }
   .-rotate-x-90 {
     --tw-rotate-x: rotateX(calc(90deg * -1));
-    transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .rotate-x-90 {
     --tw-rotate-x: rotateX(90deg);
-    transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .-rotate-y-90 {
     --tw-rotate-y: rotateY(calc(90deg * -1));
-    transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .rotate-y-90 {
     --tw-rotate-y: rotateY(90deg);
-    transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .rotate-y-180 {
     --tw-rotate-y: rotateY(180deg);
-    transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .transform {
-    transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .animate-ping {
     animation: var(--animate-ping);
@@ -1053,23 +749,47 @@
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 1px;
   }
+  .border-blue-500\/20 {
+    border-color: color-mix(in srgb, oklch(62.3% 0.214 259.815) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-blue-500) 20%, transparent);
+    }
+  }
   .border-gray-200\/20 {
-    border-color: color-mix(in oklab, var(--color-gray-200) 20%, transparent);
+    border-color: color-mix(in srgb, oklch(92.8% 0.006 264.531) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-gray-200) 20%, transparent);
+    }
   }
   .border-primary\/10 {
-    border-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+    border-color: color-mix(in srgb, oklch(0.75 0.15 30) 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+    }
   }
   .border-surface-light\/10 {
-    border-color: color-mix(in oklab, var(--color-surface-light) 10%, transparent);
+    border-color: color-mix(in srgb, oklch(0.35 0 0) 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-surface-light) 10%, transparent);
+    }
   }
   .border-surface-light\/20 {
-    border-color: color-mix(in oklab, var(--color-surface-light) 20%, transparent);
+    border-color: color-mix(in srgb, oklch(0.35 0 0) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-surface-light) 20%, transparent);
+    }
   }
   .border-white\/10 {
-    border-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+    border-color: color-mix(in srgb, #fff 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+    }
   }
   .bg-black\/20 {
-    background-color: color-mix(in oklab, var(--color-black) 20%, transparent);
+    background-color: color-mix(in srgb, #000 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-black) 20%, transparent);
+    }
   }
   .bg-blue-500 {
     background-color: var(--color-blue-500);
@@ -1077,23 +797,50 @@
   .bg-blue-600 {
     background-color: var(--color-blue-600);
   }
+  .bg-blue-900\/20 {
+    background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-blue-900) 20%, transparent);
+    }
+  }
+  .bg-dark-100\/30 {
+    background-color: color-mix(in srgb, oklch(0.15 0 0) 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-dark-100) 30%, transparent);
+    }
+  }
   .bg-dark-200 {
     background-color: var(--color-dark-200);
   }
   .bg-dark-200\/30 {
-    background-color: color-mix(in oklab, var(--color-dark-200) 30%, transparent);
+    background-color: color-mix(in srgb, oklch(0.2 0 0) 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-dark-200) 30%, transparent);
+    }
   }
   .bg-dark-200\/50 {
-    background-color: color-mix(in oklab, var(--color-dark-200) 50%, transparent);
+    background-color: color-mix(in srgb, oklch(0.2 0 0) 50%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-dark-200) 50%, transparent);
+    }
   }
   .bg-dark-200\/80 {
-    background-color: color-mix(in oklab, var(--color-dark-200) 80%, transparent);
+    background-color: color-mix(in srgb, oklch(0.2 0 0) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-dark-200) 80%, transparent);
+    }
   }
   .bg-dark-200\/95 {
-    background-color: color-mix(in oklab, var(--color-dark-200) 95%, transparent);
+    background-color: color-mix(in srgb, oklch(0.2 0 0) 95%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-dark-200) 95%, transparent);
+    }
   }
   .bg-dark-300\/50 {
-    background-color: color-mix(in oklab, var(--color-dark-300) 50%, transparent);
+    background-color: color-mix(in srgb, oklch(0.25 0 0) 50%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-dark-300) 50%, transparent);
+    }
   }
   .bg-gray-100 {
     background-color: var(--color-gray-100);
@@ -1105,182 +852,239 @@
     background-color: var(--color-primary);
   }
   .bg-primary\/5 {
-    background-color: color-mix(in oklab, var(--color-primary) 5%, transparent);
+    background-color: color-mix(in srgb, oklch(0.75 0.15 30) 5%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-primary) 5%, transparent);
+    }
   }
   .bg-primary\/10 {
-    background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+    background-color: color-mix(in srgb, oklch(0.75 0.15 30) 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+    }
   }
   .bg-primary\/20 {
-    background-color: color-mix(in oklab, var(--color-primary) 20%, transparent);
+    background-color: color-mix(in srgb, oklch(0.75 0.15 30) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-primary) 20%, transparent);
+    }
   }
   .bg-primary\/50 {
-    background-color: color-mix(in oklab, var(--color-primary) 50%, transparent);
+    background-color: color-mix(in srgb, oklch(0.75 0.15 30) 50%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-primary) 50%, transparent);
+    }
   }
   .bg-primary\/90 {
-    background-color: color-mix(in oklab, var(--color-primary) 90%, transparent);
+    background-color: color-mix(in srgb, oklch(0.75 0.15 30) 90%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-primary) 90%, transparent);
+    }
   }
   .bg-red-50 {
     background-color: var(--color-red-50);
   }
   .bg-secondary\/5 {
-    background-color: color-mix(in oklab, var(--color-secondary) 5%, transparent);
+    background-color: color-mix(in srgb, oklch(0.65 0.02 30) 5%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-secondary) 5%, transparent);
+    }
   }
   .bg-surface {
     background-color: var(--color-surface);
   }
   .bg-surface\/30 {
-    background-color: color-mix(in oklab, var(--color-surface) 30%, transparent);
+    background-color: color-mix(in srgb, oklch(0.25 0 0) 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-surface) 30%, transparent);
+    }
   }
   .bg-white {
     background-color: var(--color-white);
   }
   .bg-white\/30 {
-    background-color: color-mix(in oklab, var(--color-white) 30%, transparent);
+    background-color: color-mix(in srgb, #fff 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 30%, transparent);
+    }
   }
   .bg-linear-to-br {
-    --tw-gradient-position: to bottom right in oklab,;
+    --tw-gradient-position: to bottom right;
+    @supports (background-image: linear-gradient(in lab, red, red)) {
+      --tw-gradient-position: to bottom right in oklab;
+    }
     background-image: linear-gradient(var(--tw-gradient-stops));
   }
   .bg-linear-to-r {
-    --tw-gradient-position: to right in oklab,;
+    --tw-gradient-position: to right;
+    @supports (background-image: linear-gradient(in lab, red, red)) {
+      --tw-gradient-position: to right in oklab;
+    }
     background-image: linear-gradient(var(--tw-gradient-stops));
   }
   .bg-linear-to-tr {
-    --tw-gradient-position: to top right in oklab,;
+    --tw-gradient-position: to top right;
+    @supports (background-image: linear-gradient(in lab, red, red)) {
+      --tw-gradient-position: to top right in oklab;
+    }
     background-image: linear-gradient(var(--tw-gradient-stops));
   }
   .from-blue-500 {
     --tw-gradient-from: var(--color-blue-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-blue-500\/30 {
-    --tw-gradient-from: color-mix(in oklab, var(--color-blue-500) 30%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-from: color-mix(in srgb, oklch(62.3% 0.214 259.815) 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-from: color-mix(in oklab, var(--color-blue-500) 30%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-cyan-400 {
     --tw-gradient-from: var(--color-cyan-400);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-emerald-400 {
     --tw-gradient-from: var(--color-emerald-400);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-emerald-400\/30 {
-    --tw-gradient-from: color-mix(in oklab, var(--color-emerald-400) 30%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-from: color-mix(in srgb, oklch(76.5% 0.177 163.223) 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-from: color-mix(in oklab, var(--color-emerald-400) 30%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-gray-800 {
     --tw-gradient-from: var(--color-gray-800);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-green-500 {
     --tw-gradient-from: var(--color-green-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-pink-500 {
     --tw-gradient-from: var(--color-pink-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-primary\/20 {
-    --tw-gradient-from: color-mix(in oklab, var(--color-primary) 20%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-from: color-mix(in srgb, oklch(0.75 0.15 30) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-from: color-mix(in oklab, var(--color-primary) 20%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-purple-400 {
     --tw-gradient-from: var(--color-purple-400);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-purple-500 {
     --tw-gradient-from: var(--color-purple-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-red-500 {
     --tw-gradient-from: var(--color-red-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-text-secondary\/70 {
-    --tw-gradient-from: color-mix(in oklab, var(--color-text-secondary) 70%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-from: color-mix(in srgb, oklch(0.85 0 0) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-from: color-mix(in oklab, var(--color-text-secondary) 70%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-transparent {
     --tw-gradient-from: transparent;
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-yellow-400 {
     --tw-gradient-from: var(--color-yellow-400);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .via-white\/30 {
-    --tw-gradient-via: color-mix(in oklab, var(--color-white) 30%, transparent);
-    --tw-gradient-via-stops: var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-via: color-mix(in srgb, #fff 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-via: color-mix(in oklab, var(--color-white) 30%, transparent);
+    }
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
     --tw-gradient-stops: var(--tw-gradient-via-stops);
   }
   .to-accent-purple\/20 {
     --tw-gradient-to: color-mix(in oklab, #C084FC 20%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-blue-500 {
     --tw-gradient-to: var(--color-blue-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-blue-600 {
     --tw-gradient-to: var(--color-blue-600);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-cyan-400 {
     --tw-gradient-to: var(--color-cyan-400);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-cyan-400\/30 {
-    --tw-gradient-to: color-mix(in oklab, var(--color-cyan-400) 30%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-to: color-mix(in srgb, oklch(78.9% 0.154 211.53) 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-cyan-400) 30%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-gray-900 {
     --tw-gradient-to: var(--color-gray-900);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-green-600 {
     --tw-gradient-to: var(--color-green-600);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-orange-500 {
     --tw-gradient-to: var(--color-orange-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-pink-500 {
     --tw-gradient-to: var(--color-pink-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-pink-600 {
     --tw-gradient-to: var(--color-pink-600);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-purple-500 {
     --tw-gradient-to: var(--color-purple-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-purple-500\/30 {
-    --tw-gradient-to: color-mix(in oklab, var(--color-purple-500) 30%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-to: color-mix(in srgb, oklch(62.7% 0.265 303.9) 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-purple-500) 30%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-purple-600 {
     --tw-gradient-to: var(--color-purple-600);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-red-600 {
     --tw-gradient-to: var(--color-red-600);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-text-secondary\/40 {
-    --tw-gradient-to: color-mix(in oklab, var(--color-text-secondary) 40%, transparent);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-to: color-mix(in srgb, oklch(0.85 0 0) 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-text-secondary) 40%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-transparent {
     --tw-gradient-to: transparent;
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .to-yellow-500 {
     --tw-gradient-to: var(--color-yellow-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .bg-clip-text {
     background-clip: text;
@@ -1428,6 +1232,12 @@
     --tw-tracking: var(--tracking-wider);
     letter-spacing: var(--tracking-wider);
   }
+  .text-blue-200\/80 {
+    color: color-mix(in srgb, oklch(88.2% 0.059 254.128) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-blue-200) 80%, transparent);
+    }
+  }
   .text-blue-300 {
     color: var(--color-blue-300);
   }
@@ -1455,6 +1265,9 @@
   .text-green-300 {
     color: var(--color-green-300);
   }
+  .text-green-400 {
+    color: var(--color-green-400);
+  }
   .text-green-500 {
     color: var(--color-green-500);
   }
@@ -1468,10 +1281,16 @@
     color: var(--color-primary);
   }
   .text-primary\/80 {
-    color: color-mix(in oklab, var(--color-primary) 80%, transparent);
+    color: color-mix(in srgb, oklch(0.75 0.15 30) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-primary) 80%, transparent);
+    }
   }
   .text-primary\/90 {
-    color: color-mix(in oklab, var(--color-primary) 90%, transparent);
+    color: color-mix(in srgb, oklch(0.75 0.15 30) 90%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-primary) 90%, transparent);
+    }
   }
   .text-purple-400 {
     color: var(--color-purple-400);
@@ -1501,7 +1320,10 @@
     color: var(--color-white);
   }
   .text-white\/90 {
-    color: color-mix(in oklab, var(--color-white) 90%, transparent);
+    color: color-mix(in srgb, #fff 90%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-white) 90%, transparent);
+    }
   }
   .text-yellow-500 {
     color: var(--color-yellow-500);
@@ -1537,17 +1359,22 @@
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .shadow-black\/5 {
-    --tw-shadow-color: color-mix(in oklab, var(--color-black) 5%, transparent);
+    --tw-shadow-color: color-mix(in srgb, #000 5%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-black) 5%, transparent) var(--tw-shadow-alpha), transparent);
+    }
   }
   .shadow-primary\/5 {
-    --tw-shadow-color: color-mix(in oklab, var(--color-primary) 5%, transparent);
+    --tw-shadow-color: color-mix(in srgb, oklch(0.75 0.15 30) 5%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-primary) 5%, transparent) var(--tw-shadow-alpha), transparent);
+    }
   }
   .shadow-primary\/20 {
-    --tw-shadow-color: color-mix(in oklab, var(--color-primary) 20%, transparent);
-  }
-  .blur {
-    --tw-blur: blur(8px);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+    --tw-shadow-color: color-mix(in srgb, oklch(0.75 0.15 30) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-primary) 20%, transparent) var(--tw-shadow-alpha), transparent);
+    }
   }
   .blur-3xl {
     --tw-blur: blur(var(--blur-3xl));
@@ -1563,10 +1390,6 @@
   }
   .blur-xl {
     --tw-blur: blur(var(--blur-xl));
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .drop-shadow {
-    --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow( 0 1px 1px rgb(0 0 0 / 0.06));
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .filter {
@@ -1588,7 +1411,7 @@
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
   .transition {
-    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter;
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
@@ -1628,12 +1451,12 @@
     --tw-ease: var(--ease-out);
     transition-timing-function: var(--ease-out);
   }
-  .backface-hidden {
-    backface-visibility: hidden;
-  }
   .select-none {
     -webkit-user-select: none;
     user-select: none;
+  }
+  .backface-hidden {
+    backface-visibility: hidden;
   }
   .group-hover\:w-full {
     &:is(:where(.group):hover *) {
@@ -1703,21 +1526,30 @@
   .hover\:border-primary\/20 {
     &:hover {
       @media (hover: hover) {
-        border-color: color-mix(in oklab, var(--color-primary) 20%, transparent);
+        border-color: color-mix(in srgb, oklch(0.75 0.15 30) 20%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          border-color: color-mix(in oklab, var(--color-primary) 20%, transparent);
+        }
       }
     }
   }
   .hover\:border-white\/20 {
     &:hover {
       @media (hover: hover) {
-        border-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+        border-color: color-mix(in srgb, #fff 20%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          border-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+        }
       }
     }
   }
   .hover\:bg-dark-200\/70 {
     &:hover {
       @media (hover: hover) {
-        background-color: color-mix(in oklab, var(--color-dark-200) 70%, transparent);
+        background-color: color-mix(in srgb, oklch(0.2 0 0) 70%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-dark-200) 70%, transparent);
+        }
       }
     }
   }
@@ -1731,28 +1563,40 @@
   .hover\:bg-primary\/10 {
     &:hover {
       @media (hover: hover) {
-        background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+        background-color: color-mix(in srgb, oklch(0.75 0.15 30) 10%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+        }
       }
     }
   }
   .hover\:bg-primary\/30 {
     &:hover {
       @media (hover: hover) {
-        background-color: color-mix(in oklab, var(--color-primary) 30%, transparent);
+        background-color: color-mix(in srgb, oklch(0.75 0.15 30) 30%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-primary) 30%, transparent);
+        }
       }
     }
   }
   .hover\:bg-surface-light\/10 {
     &:hover {
       @media (hover: hover) {
-        background-color: color-mix(in oklab, var(--color-surface-light) 10%, transparent);
+        background-color: color-mix(in srgb, oklch(0.35 0 0) 10%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-surface-light) 10%, transparent);
+        }
       }
     }
   }
   .hover\:bg-surface-light\/20 {
     &:hover {
       @media (hover: hover) {
-        background-color: color-mix(in oklab, var(--color-surface-light) 20%, transparent);
+        background-color: color-mix(in srgb, oklch(0.35 0 0) 20%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-surface-light) 20%, transparent);
+        }
       }
     }
   }
@@ -1760,7 +1604,7 @@
     &:hover {
       @media (hover: hover) {
         --tw-gradient-from: var(--color-purple-500);
-        --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+        --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
       }
     }
   }
@@ -1768,7 +1612,7 @@
     &:hover {
       @media (hover: hover) {
         --tw-gradient-to: var(--color-blue-500);
-        --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position,) var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+        --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
       }
     }
   }
@@ -1796,7 +1640,10 @@
   .hover\:text-primary\/80 {
     &:hover {
       @media (hover: hover) {
-        color: color-mix(in oklab, var(--color-primary) 80%, transparent);
+        color: color-mix(in srgb, oklch(0.75 0.15 30) 80%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          color: color-mix(in oklab, var(--color-primary) 80%, transparent);
+        }
       }
     }
   }
@@ -1833,21 +1680,30 @@
   .hover\:shadow-primary\/10 {
     &:hover {
       @media (hover: hover) {
-        --tw-shadow-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+        --tw-shadow-color: color-mix(in srgb, oklch(0.75 0.15 30) 10%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-primary) 10%, transparent) var(--tw-shadow-alpha), transparent);
+        }
       }
     }
   }
   .hover\:shadow-primary\/30 {
     &:hover {
       @media (hover: hover) {
-        --tw-shadow-color: color-mix(in oklab, var(--color-primary) 30%, transparent);
+        --tw-shadow-color: color-mix(in srgb, oklch(0.75 0.15 30) 30%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-primary) 30%, transparent) var(--tw-shadow-alpha), transparent);
+        }
       }
     }
   }
   .hover\:shadow-purple-500\/20 {
     &:hover {
       @media (hover: hover) {
-        --tw-shadow-color: color-mix(in oklab, var(--color-purple-500) 20%, transparent);
+        --tw-shadow-color: color-mix(in srgb, oklch(62.7% 0.265 303.9) 20%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-purple-500) 20%, transparent) var(--tw-shadow-alpha), transparent);
+        }
       }
     }
   }
@@ -1976,7 +1832,10 @@
   }
   .dark\:shadow-white\/5 {
     &:where(.dark, .dark *) {
-      --tw-shadow-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+      --tw-shadow-color: color-mix(in srgb, #fff 5%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-white) 5%, transparent) var(--tw-shadow-alpha), transparent);
+      }
     }
   }
 }
@@ -1985,33 +1844,73 @@
     border-color: var(--color-gray-200, currentcolor);
   }
 }
+@supports (-webkit-backdrop-filter: blur(1px)) {
+  .backdrop-blur-xs {
+    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
+  }
+  .backdrop-blur-md {
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+  }
+  .backdrop-blur-lg {
+    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
+  }
+}
+@media screen and (-webkit-min-device-pixel-ratio: 1) {
+  .transform-gpu {
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    -webkit-perspective: 1000px;
+    perspective: 1000px;
+  }
+  [style*="transform"] {
+    will-change: transform;
+    -webkit-transform-style: preserve-3d;
+    transform-style: preserve-3d;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
 @keyframes down {
   0% {
-    transform: translateY(0%);
+    transform: translateY(0%) translateZ(0);
+    will-change: transform;
   }
   100% {
-    transform: translateY(calc(45vh - 8rem));
+    transform: translateY(calc(45vh - 8rem)) translateZ(0);
   }
 }
 @keyframes shimmer {
   0% {
-    transform: translateX(-100%);
+    transform: translateX(-100%) translateZ(0);
+    will-change: transform;
   }
   100% {
-    transform: translateX(100%);
+    transform: translateX(100%) translateZ(0);
   }
 }
 @keyframes float {
   0%, 100% {
-    transform: translateY(0);
+    transform: translateY(0) translateZ(0);
+    will-change: transform;
   }
   50% {
-    transform: translateY(-10px);
+    transform: translateY(-10px) translateZ(0);
   }
 }
 @keyframes glow {
   0%, 100% {
     filter: brightness(1);
+    will-change: filter;
   }
   50% {
     filter: brightness(1.2);
@@ -2019,15 +1918,22 @@
 }
 .animate-move-down {
   animation: down 3s linear infinite;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 .animate-shimmer {
   animation: shimmer 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 .animate-float {
   animation: float 3s ease-in-out infinite;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 .animate-glow {
   animation: glow 2s ease-in-out infinite;
+  will-change: filter;
 }
 .bg-gradient-dark {
   background: linear-gradient(to right, var(--color-dark-50), var(--color-dark-100));
@@ -2060,7 +1966,10 @@
   transition-duration: var(--tw-duration, var(--default-transition-duration));
   --tw-duration: 300ms;
   transition-duration: 300ms;
-  border-color: color-mix(in oklab, var(--bg-primary) 80%, var(--text-primary));
+  border-color: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in oklab, var(--bg-primary) 80%, var(--text-primary));
+  }
   color: var(--text-primary);
 }
 .btn {
@@ -2095,7 +2004,10 @@
 }
 .nav-link:hover {
   color: var(--text-primary);
-  background-color: color-mix(in oklab, var(--bg-primary) 90%, var(--text-primary));
+  background-color: var(--bg-primary);
+  @supports (color: color-mix(in lab, red, red)) {
+    background-color: color-mix(in oklab, var(--bg-primary) 90%, var(--text-primary));
+  }
 }
 .code-block {
   border-radius: var(--radius-lg);
@@ -2118,55 +2030,60 @@
 }
 @keyframes gentle-float {
   0%, 100% {
-    transform: translateY(0);
+    transform: translateY(0) translateZ(0);
+    will-change: transform;
   }
   50% {
-    transform: translateY(-5px);
+    transform: translateY(-8px) translateZ(0);
   }
 }
 .logo-float {
-  animation: gentle-float 3s ease-in-out infinite;
+  animation: gentle-float 4s ease-in-out infinite;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 @keyframes float {
   0%, 100% {
-    transform: translateY(0);
+    transform: translateY(0) translateZ(0);
+    will-change: transform;
   }
   50% {
-    transform: translateY(-10px);
+    transform: translateY(-10px) translateZ(0);
   }
 }
 @keyframes glow {
   0%, 100% {
-    filter: brightness(1);
+    filter: brightness(1) contrast(1);
+    will-change: filter;
   }
   50% {
-    filter: brightness(1.2);
+    filter: brightness(1.2) contrast(1.1);
   }
 }
 @keyframes performance-pulse {
   0%, 100% {
-    box-shadow: var(--shadow-glow-perf);
-    transform: scale(1);
+    transform: scale(1) translateZ(0);
+    opacity: 1;
+    will-change: transform, opacity;
   }
   50% {
-    box-shadow: none;
-    transform: scale(0.98);
+    transform: scale(1.05) translateZ(0);
+    opacity: 0.9;
   }
 }
 .animate-float {
   animation: float 3s ease-in-out infinite;
-  transform-style: preserve-3d;
-  will-change: transform;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 .animate-glow {
   animation: glow 2s ease-in-out infinite;
-  transform-style: preserve-3d;
-  will-change: transform;
+  will-change: filter;
 }
 .animate-performance {
-  animation: performance-pulse 1.5s var(--ease-spring) infinite;
-  transform-style: preserve-3d;
-  will-change: transform;
+  animation: performance-pulse 2s ease-in-out infinite;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 .container-lg {
   margin-inline: auto;
@@ -2244,56 +2161,19 @@
 }
 @keyframes rust-pulse {
   0%, 100% {
-    box-shadow: 0 0 0 0 var(--color-primary);
+    transform: scale(1) translateZ(0);
+    filter: brightness(1) hue-rotate(0deg);
+    will-change: transform, filter;
   }
   50% {
-    box-shadow: 0 0 20px 0 var(--color-primary);
+    transform: scale(1.02) translateZ(0);
+    filter: brightness(1.1) hue-rotate(5deg);
   }
 }
 .animate-rust-pulse {
-  animation: rust-pulse 2s infinite;
-}
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-@keyframes ping {
-  75%, 100% {
-    transform: scale(2);
-    opacity: 0;
-  }
-}
-@keyframes pulse {
-  50% {
-    opacity: 0.5;
-  }
-}
-@keyframes bounce {
-  0%, 100% {
-    transform: translateY(-25%);
-    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
-  }
-  50% {
-    transform: none;
-    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
-  }
-}
-@keyframes down {
-  0% {
-    transform: translateY(0%);
-  }
-  100% {
-    transform: translateY(calc(45vh - 8rem));
-  }
-}
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
+  animation: rust-pulse 3s ease-in-out infinite;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
 }
 @property --tw-translate-x {
   syntax: "*";
@@ -2313,27 +2193,22 @@
 @property --tw-rotate-x {
   syntax: "*";
   inherits: false;
-  initial-value: rotateX(0);
 }
 @property --tw-rotate-y {
   syntax: "*";
   inherits: false;
-  initial-value: rotateY(0);
 }
 @property --tw-rotate-z {
   syntax: "*";
   inherits: false;
-  initial-value: rotateZ(0);
 }
 @property --tw-skew-x {
   syntax: "*";
   inherits: false;
-  initial-value: skewX(0);
 }
 @property --tw-skew-y {
   syntax: "*";
   inherits: false;
-  initial-value: skewY(0);
 }
 @property --tw-space-y-reverse {
   syntax: "*";
@@ -2413,6 +2288,11 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
 @property --tw-inset-shadow {
   syntax: "*";
   inherits: false;
@@ -2421,6 +2301,11 @@
 @property --tw-inset-shadow-color {
   syntax: "*";
   inherits: false;
+}
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
 }
 @property --tw-ring-color {
   syntax: "*";
@@ -2495,6 +2380,23 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-drop-shadow {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-drop-shadow-size {
+  syntax: "*";
+  inherits: false;
+}
 @property --tw-backdrop-blur {
   syntax: "*";
   inherits: false;
@@ -2553,4 +2455,101 @@
   syntax: "*";
   inherits: false;
   initial-value: 1;
+}
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+@keyframes down {
+  0% {
+    transform: translateY(0%);
+  }
+  100% {
+    transform: translateY(calc(45vh - 8rem));
+  }
+}
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@layer properties {
+  @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
+    *, ::before, ::after, ::backdrop {
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
+      --tw-space-y-reverse: 0;
+      --tw-space-x-reverse: 0;
+      --tw-border-style: solid;
+      --tw-gradient-position: initial;
+      --tw-gradient-from: #0000;
+      --tw-gradient-via: #0000;
+      --tw-gradient-to: #0000;
+      --tw-gradient-stops: initial;
+      --tw-gradient-via-stops: initial;
+      --tw-gradient-from-position: 0%;
+      --tw-gradient-via-position: 50%;
+      --tw-gradient-to-position: 100%;
+      --tw-leading: initial;
+      --tw-font-weight: initial;
+      --tw-tracking: initial;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-blur: initial;
+      --tw-brightness: initial;
+      --tw-contrast: initial;
+      --tw-grayscale: initial;
+      --tw-hue-rotate: initial;
+      --tw-invert: initial;
+      --tw-opacity: initial;
+      --tw-saturate: initial;
+      --tw-sepia: initial;
+      --tw-drop-shadow: initial;
+      --tw-drop-shadow-color: initial;
+      --tw-drop-shadow-alpha: 100%;
+      --tw-drop-shadow-size: initial;
+      --tw-backdrop-blur: initial;
+      --tw-backdrop-brightness: initial;
+      --tw-backdrop-contrast: initial;
+      --tw-backdrop-grayscale: initial;
+      --tw-backdrop-hue-rotate: initial;
+      --tw-backdrop-invert: initial;
+      --tw-backdrop-opacity: initial;
+      --tw-backdrop-saturate: initial;
+      --tw-backdrop-sepia: initial;
+      --tw-duration: initial;
+      --tw-ease: initial;
+      --tw-scale-x: 1;
+      --tw-scale-y: 1;
+      --tw-scale-z: 1;
+    }
+  }
 }

--- a/docs/input.css
+++ b/docs/input.css
@@ -3,94 +3,139 @@
 @config './tailwind.config.js';
 
 @theme {
-  /* Typography */
-  --font-display: 'JetBrains Mono', monospace;
-  --font-body: 'Inter', sans-serif;
+    /* Typography */
+    --font-display: 'JetBrains Mono', monospace;
+    --font-body: 'Inter', sans-serif;
 
-  /* Base theme colors */
-  --color-background: oklch(0.04 0 0);
-  /* #0A0F1A */
-  --color-background-light: oklch(1 0 0);
-  /* #FFFFFF */
+    /* Base theme colors with Safari fallbacks */
+    --color-background: #0a0f1a;
+    /* Safari fallback */
+    --color-background: oklch(0.04 0 0);
+    --color-background-light: #ffffff;
+    /* Safari fallback */
+    --color-background-light: oklch(1 0 0);
 
-  /* Dark theme colors */
-  --color-dark-50: oklch(0.1 0 0);
-  --color-dark-100: oklch(0.15 0 0);
-  --color-dark-200: oklch(0.2 0 0);
-  --color-dark-300: oklch(0.25 0 0);
-  --color-dark-400: oklch(0.3 0 0);
+    /* Dark theme colors with Safari fallbacks */
+    --color-dark-50: #1a1a1a;
+    /* Safari fallback */
+    --color-dark-50: oklch(0.1 0 0);
+    --color-dark-100: #262626;
+    /* Safari fallback */
+    --color-dark-100: oklch(0.15 0 0);
+    --color-dark-200: #333333;
+    /* Safari fallback */
+    --color-dark-200: oklch(0.2 0 0);
+    --color-dark-300: #404040;
+    /* Safari fallback */
+    --color-dark-300: oklch(0.25 0 0);
+    --color-dark-400: #4d4d4d;
+    /* Safari fallback */
+    --color-dark-400: oklch(0.3 0 0);
 
-  /* Light theme colors */
-  --color-light-50: oklch(0.98 0 0);
-  --color-light-100: oklch(0.95 0 0);
-  --color-light-200: oklch(0.9 0 0);
-  --color-light-300: oklch(0.85 0 0);
-  --color-light-400: oklch(0.8 0 0);
+    /* Light theme colors with Safari fallbacks */
+    --color-light-50: #fafafa;
+    /* Safari fallback */
+    --color-light-50: oklch(0.98 0 0);
+    --color-light-100: #f5f5f5;
+    /* Safari fallback */
+    --color-light-100: oklch(0.95 0 0);
+    --color-light-200: #e5e5e5;
+    /* Safari fallback */
+    --color-light-200: oklch(0.9 0 0);
+    --color-light-300: #d4d4d4;
+    /* Safari fallback */
+    --color-light-300: oklch(0.85 0 0);
+    --color-light-400: #a3a3a3;
+    /* Safari fallback */
+    --color-light-400: oklch(0.8 0 0);
 
-  /* Primary colors - Rust orange */
-  --color-primary: oklch(0.75 0.15 30);
-  /* #CD7F32 - Rust bronze */
-  --color-primary-light: oklch(0.8 0.15 30);
-  /* #FFA07A - Light salmon */
-  --color-primary-dark: oklch(0.7 0.15 30);
-  /* #B87333 - Bronze */
-  --color-primary-hover: oklch(0.85 0.15 30);
+    /* Primary colors - Rust orange with Safari fallbacks */
+    --color-primary: #cd7f32;
+    /* Safari fallback */
+    --color-primary: oklch(0.75 0.15 30);
+    --color-primary-light: #ffa07a;
+    /* Safari fallback */
+    --color-primary-light: oklch(0.8 0.15 30);
+    --color-primary-dark: #b87333;
+    /* Safari fallback */
+    --color-primary-dark: oklch(0.7 0.15 30);
+    --color-primary-hover: #ff8c42;
+    /* Safari fallback */
+    --color-primary-hover: oklch(0.85 0.15 30);
 
-  /* Secondary colors - Rust gray */
-  --color-secondary: oklch(0.65 0.02 30);
-  /* #8B4513 - Saddle brown */
-  --color-secondary-light: oklch(0.9 0.02 30);
-  /* #DEB887 - Burly wood */
-  --color-secondary-dark: oklch(0.35 0.02 30);
-  /* #A0522D - Sienna */
+    /* Secondary colors - Rust gray with Safari fallbacks */
+    --color-secondary: #8b7355;
+    /* Safari fallback */
+    --color-secondary: oklch(0.65 0.02 30);
+    --color-secondary-light: #deb887;
+    /* Safari fallback */
+    --color-secondary-light: oklch(0.9 0.02 30);
+    --color-secondary-dark: #a0522d;
+    /* Safari fallback */
+    --color-secondary-dark: oklch(0.35 0.02 30);
 
-  /* Accent colors */
-  --color-accent-rust: oklch(0.75 0.15 30);
-  /* #CD7F32 - Rust bronze */
-  --color-accent-rust-hover: oklch(0.85 0.15 30);
-  /* #FFA07A - Light salmon */
+    /* Accent colors with Safari fallbacks */
+    --color-accent-rust: #cd7f32;
+    /* Safari fallback */
+    --color-accent-rust: oklch(0.75 0.15 30);
+    --color-accent-rust-hover: #ffa07a;
+    /* Safari fallback */
+    --color-accent-rust-hover: oklch(0.85 0.15 30);
 
-  /* Surface colors */
-  --color-surface: oklch(0.25 0 0);
-  /* #1F2937 */
-  --color-surface-light: oklch(0.35 0 0);
-  /* #374151 */
-  --color-surface-dark: oklch(0.15 0 0);
-  /* #111827 */
-  --color-surface-hover: oklch(0.15 0 0 / 0.7);
-  /* #111827B3 */
+    /* Surface colors with Safari fallbacks */
+    --color-surface: #1f2937;
+    /* Safari fallback */
+    --color-surface: oklch(0.25 0 0);
+    --color-surface-light: #374151;
+    /* Safari fallback */
+    --color-surface-light: oklch(0.35 0 0);
+    --color-surface-dark: #111827;
+    /* Safari fallback */
+    --color-surface-dark: oklch(0.15 0 0);
+    --color-surface-hover: rgba(17, 24, 39, 0.7);
+    /* Safari fallback */
+    --color-surface-hover: oklch(0.15 0 0 / 0.7);
 
-  /* Text colors */
-  --color-text-primary: oklch(1 0 0);
-  /* #FFFFFF */
-  --color-text-secondary: oklch(0.85 0 0);
-  /* #D1D5DB */
-  --color-text-muted: oklch(0.65 0 0);
-  /* #9CA3AF */
+    /* Text colors with Safari fallbacks */
+    --color-text-primary: #ffffff;
+    /* Safari fallback */
+    --color-text-primary: oklch(1 0 0);
+    --color-text-secondary: #d1d5db;
+    /* Safari fallback */
+    --color-text-secondary: oklch(0.85 0 0);
+    --color-text-muted: #9ca3af;
+    /* Safari fallback */
+    --color-text-muted: oklch(0.65 0 0);
 
-  /* Text colors for light mode */
-  --color-text-primary-light: oklch(0.15 0 0);
-  --color-text-secondary-light: oklch(0.25 0 0);
-  --color-text-muted-light: oklch(0.35 0 0);
+    /* Text colors for light mode with Safari fallbacks */
+    --color-text-primary-light: #262626;
+    /* Safari fallback */
+    --color-text-primary-light: oklch(0.15 0 0);
+    --color-text-secondary-light: #404040;
+    /* Safari fallback */
+    --color-text-secondary-light: oklch(0.25 0 0);
+    --color-text-muted-light: #525252;
+    /* Safari fallback */
+    --color-text-muted-light: oklch(0.35 0 0);
 
-  /* Transitions */
-  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  --ease-snappy: cubic-bezier(0.2, 0, 0, 1);
-  --transition-fast: 150ms var(--ease-snappy);
-  --transition-medium: 300ms var(--ease-smooth);
-  --transition-spring: 500ms var(--ease-spring);
+    /* Transitions */
+    --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+    --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    --ease-snappy: cubic-bezier(0.2, 0, 0, 1);
+    --transition-fast: 150ms var(--ease-snappy);
+    --transition-medium: 300ms var(--ease-smooth);
+    --transition-spring: 500ms var(--ease-spring);
 
-  /* Shadows */
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg:
-    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --shadow-neumorphic:
-    20px 20px 60px #d9d9d9, -20px -20px 60px #ffffff,
-    0 4px 6px -1px rgba(255, 255, 255, 0.1),
-    0 2px 4px -1px rgba(255, 255, 255, 0.06),
-    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    /* Shadows */
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    --shadow-lg:
+        0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    --shadow-neumorphic:
+        20px 20px 60px #d9d9d9, -20px -20px 60px #ffffff,
+        0 4px 6px -1px rgba(255, 255, 255, 0.1),
+        0 2px 4px -1px rgba(255, 255, 255, 0.06),
+        0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
 /*
@@ -102,33 +147,85 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
-  }
+
+    *,
+    ::after,
+    ::before,
+    ::backdrop,
+    ::file-selector-button {
+        border-color: var(--color-gray-200, currentcolor);
+    }
 }
 
-/* Keyframes */
+/* Safari-specific optimizations */
+@supports (-webkit-backdrop-filter: blur(1px)) {
+    .backdrop-blur-xs {
+        -webkit-backdrop-filter: blur(4px);
+        backdrop-filter: blur(4px);
+    }
+
+    .backdrop-blur-md {
+        -webkit-backdrop-filter: blur(12px);
+        backdrop-filter: blur(12px);
+    }
+
+    .backdrop-blur-lg {
+        -webkit-backdrop-filter: blur(16px);
+        backdrop-filter: blur(16px);
+    }
+}
+
+/* Safari transform optimization */
+@media screen and (-webkit-min-device-pixel-ratio: 1) {
+    .transform-gpu {
+        -webkit-transform: translateZ(0);
+        transform: translateZ(0);
+        -webkit-backface-visibility: hidden;
+        backface-visibility: hidden;
+        -webkit-perspective: 1000px;
+        perspective: 1000px;
+    }
+
+    /* Optimize animations for Safari */
+    [style*="transform"] {
+        will-change: transform;
+        -webkit-transform-style: preserve-3d;
+        transform-style: preserve-3d;
+    }
+}
+
+/* Reduced motion support for Safari accessibility */
+@media (prefers-reduced-motion: reduce) {
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+/* Keyframes optimized for Safari */
 @keyframes down {
     0% {
-        transform: translateY(0%);
+        transform: translateY(0%) translateZ(0);
+        will-change: transform;
     }
 
     100% {
-        transform: translateY(calc(45vh - 8rem));
+        transform: translateY(calc(45vh - 8rem)) translateZ(0);
     }
 }
 
 @keyframes shimmer {
     0% {
-        transform: translateX(-100%);
+        transform: translateX(-100%) translateZ(0);
+        will-change: transform;
     }
 
     100% {
-        transform: translateX(100%);
+        transform: translateX(100%) translateZ(0);
     }
 }
 
@@ -136,11 +233,12 @@
 
     0%,
     100% {
-        transform: translateY(0);
+        transform: translateY(0) translateZ(0);
+        will-change: transform;
     }
 
     50% {
-        transform: translateY(-10px);
+        transform: translateY(-10px) translateZ(0);
     }
 }
 
@@ -149,6 +247,7 @@
     0%,
     100% {
         filter: brightness(1);
+        will-change: filter;
     }
 
     50% {
@@ -156,21 +255,28 @@
     }
 }
 
-/* Animation classes */
+/* Animation classes optimized for Safari */
 .animate-move-down {
     animation: down 3s linear infinite;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
 }
 
 .animate-shimmer {
     animation: shimmer 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
 }
 
 .animate-float {
     animation: float 3s ease-in-out infinite;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
 }
 
 .animate-glow {
     animation: glow 2s ease-in-out infinite;
+    will-change: filter;
 }
 
 /* Gradient backgrounds */
@@ -261,28 +367,31 @@
 
     0%,
     100% {
-        transform: translateY(0);
+        transform: translateY(0) translateZ(0);
+        will-change: transform;
     }
 
     50% {
-        transform: translateY(-5px);
+        transform: translateY(-8px) translateZ(0);
     }
 }
 
 .logo-float {
-    animation: gentle-float 3s ease-in-out infinite;
+    animation: gentle-float 4s ease-in-out infinite;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
 }
 
-/* Animation keyframes */
 @keyframes float {
 
     0%,
     100% {
-        transform: translateY(0);
+        transform: translateY(0) translateZ(0);
+        will-change: transform;
     }
 
     50% {
-        transform: translateY(-10px);
+        transform: translateY(-10px) translateZ(0);
     }
 }
 
@@ -290,11 +399,12 @@
 
     0%,
     100% {
-        filter: brightness(1);
+        filter: brightness(1) contrast(1);
+        will-change: filter;
     }
 
     50% {
-        filter: brightness(1.2);
+        filter: brightness(1.2) contrast(1.1);
     }
 }
 
@@ -302,33 +412,32 @@
 
     0%,
     100% {
-        box-shadow: var(--shadow-glow-perf);
-        transform: scale(1);
+        transform: scale(1) translateZ(0);
+        opacity: 1;
+        will-change: transform, opacity;
     }
 
     50% {
-        box-shadow: none;
-        transform: scale(0.98);
+        transform: scale(1.05) translateZ(0);
+        opacity: 0.9;
     }
 }
 
-/* Animation classes */
 .animate-float {
     animation: float 3s ease-in-out infinite;
-    transform-style: preserve-3d;
-    will-change: transform;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
 }
 
 .animate-glow {
     animation: glow 2s ease-in-out infinite;
-    transform-style: preserve-3d;
-    will-change: transform;
+    will-change: filter;
 }
 
 .animate-performance {
-    animation: performance-pulse 1.5s var(--ease-spring) infinite;
-    transform-style: preserve-3d;
-    will-change: transform;
+    animation: performance-pulse 2s ease-in-out infinite;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
 }
 
 /* Layout utilities */
@@ -398,14 +507,19 @@
 
     0%,
     100% {
-        box-shadow: 0 0 0 0 var(--color-primary);
+        transform: scale(1) translateZ(0);
+        filter: brightness(1) hue-rotate(0deg);
+        will-change: transform, filter;
     }
 
     50% {
-        box-shadow: 0 0 20px 0 var(--color-primary);
+        transform: scale(1.02) translateZ(0);
+        filter: brightness(1.1) hue-rotate(5deg);
     }
 }
 
 .animate-rust-pulse {
-    animation: rust-pulse 2s infinite;
+    animation: rust-pulse 3s ease-in-out infinite;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
 }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5,8 +5,62 @@
   "packages": {
     "": {
       "dependencies": {
-        "@tailwindcss/cli": "^4.1.4",
-        "tailwindcss": "^4.1.4"
+        "@tailwindcss/cli": "^4.1.11",
+        "tailwindcss": "^4.1.11"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -305,66 +359,70 @@
       }
     },
     "node_modules/@tailwindcss/cli": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.4.tgz",
-      "integrity": "sha512-gP05Qihh+cZ2FqD5fa0WJXx3KEk2YWUYv/RBKAyiOg0V4vYVDr/xlLc0sacpnVEXM45BVUR9U2hsESufYs6YTA==",
-      "license": "MIT",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.11.tgz",
+      "integrity": "sha512-7RAFOrVaXCFz5ooEG36Kbh+sMJiI2j4+Ozp71smgjnLfBRu7DTfoq8DsTvzse2/6nDeo2M3vS/FGaxfDgr3rtQ==",
       "dependencies": {
         "@parcel/watcher": "^2.5.1",
-        "@tailwindcss/node": "4.1.4",
-        "@tailwindcss/oxide": "4.1.4",
+        "@tailwindcss/node": "4.1.11",
+        "@tailwindcss/oxide": "4.1.11",
         "enhanced-resolve": "^5.18.1",
         "mri": "^1.2.0",
         "picocolors": "^1.1.1",
-        "tailwindcss": "4.1.4"
+        "tailwindcss": "4.1.11"
       },
       "bin": {
         "tailwindcss": "dist/index.mjs"
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.4.tgz",
-      "integrity": "sha512-MT5118zaiO6x6hNA04OWInuAiP1YISXql8Z+/Y8iisV5nuhM8VXlyhRuqc2PEviPszcXI66W44bCIk500Oolhw==",
-      "license": "MIT",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.11.tgz",
+      "integrity": "sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==",
       "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
         "enhanced-resolve": "^5.18.1",
         "jiti": "^2.4.2",
-        "lightningcss": "1.29.2",
-        "tailwindcss": "4.1.4"
+        "lightningcss": "1.30.1",
+        "magic-string": "^0.30.17",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.11"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.4.tgz",
-      "integrity": "sha512-p5wOpXyOJx7mKh5MXh5oKk+kqcz8T+bA3z/5VWWeQwFrmuBItGwz8Y2CHk/sJ+dNb9B0nYFfn0rj/cKHZyjahQ==",
-      "license": "MIT",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.11.tgz",
+      "integrity": "sha512-Q69XzrtAhuyfHo+5/HMgr1lAiPP/G40OMFAnws7xcFEYqcypZmdW8eGXaOUIeOl1dzPJBPENXgbjsOyhg2nkrg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "detect-libc": "^2.0.4",
+        "tar": "^7.4.3"
+      },
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.4",
-        "@tailwindcss/oxide-darwin-x64": "4.1.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.4"
+        "@tailwindcss/oxide-android-arm64": "4.1.11",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.11",
+        "@tailwindcss/oxide-darwin-x64": "4.1.11",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.11",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.11",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.11",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.11",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.11",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.11",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.11",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.11",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.11"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.4.tgz",
-      "integrity": "sha512-xMMAe/SaCN/vHfQYui3fqaBDEXMu22BVwQ33veLc8ep+DNy7CWN52L+TTG9y1K397w9nkzv+Mw+mZWISiqhmlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.11.tgz",
+      "integrity": "sha512-3IfFuATVRUMZZprEIx9OGDjG3Ou3jG4xQzNTvjDoKmU9JdmoCohQJ83MYd0GPnQIu89YoJqvMM0G3uqLRFtetg==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -374,13 +432,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.4.tgz",
-      "integrity": "sha512-JGRj0SYFuDuAGilWFBlshcexev2hOKfNkoX+0QTksKYq2zgF9VY/vVMq9m8IObYnLna0Xlg+ytCi2FN2rOL0Sg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.11.tgz",
+      "integrity": "sha512-ESgStEOEsyg8J5YcMb1xl8WFOXfeBmrhAwGsFxxB2CxY9evy63+AtpbDLAyRkJnxLy2WsD1qF13E97uQyP1lfQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -390,13 +447,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.4.tgz",
-      "integrity": "sha512-sdDeLNvs3cYeWsEJ4H1DvjOzaGios4QbBTNLVLVs0XQ0V95bffT3+scptzYGPMjm7xv4+qMhCDrkHwhnUySEzA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.11.tgz",
+      "integrity": "sha512-EgnK8kRchgmgzG6jE10UQNaH9Mwi2n+yw1jWmof9Vyg2lpKNX2ioe7CJdf9M5f8V9uaQxInenZkOxnTVL3fhAw==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -406,13 +462,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.4.tgz",
-      "integrity": "sha512-VHxAqxqdghM83HslPhRsNhHo91McsxRJaEnShJOMu8mHmEj9Ig7ToHJtDukkuLWLzLboh2XSjq/0zO6wgvykNA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.11.tgz",
+      "integrity": "sha512-xdqKtbpHs7pQhIKmqVpxStnY1skuNh4CtbcyOHeX1YBE0hArj2romsFGb6yUmzkq/6M24nkxDqU8GYrKrz+UcA==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -422,13 +477,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.4.tgz",
-      "integrity": "sha512-OTU/m/eV4gQKxy9r5acuesqaymyeSCnsx1cFto/I1WhPmi5HDxX1nkzb8KYBiwkHIGg7CTfo/AcGzoXAJBxLfg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.11.tgz",
+      "integrity": "sha512-ryHQK2eyDYYMwB5wZL46uoxz2zzDZsFBwfjssgB7pzytAeCCa6glsiJGjhTEddq/4OsIjsLNMAiMlHNYnkEEeg==",
       "cpu": [
         "arm"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -438,13 +492,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.4.tgz",
-      "integrity": "sha512-hKlLNvbmUC6z5g/J4H+Zx7f7w15whSVImokLPmP6ff1QqTVE+TxUM9PGuNsjHvkvlHUtGTdDnOvGNSEUiXI1Ww==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.11.tgz",
+      "integrity": "sha512-mYwqheq4BXF83j/w75ewkPJmPZIqqP1nhoghS9D57CLjsh3Nfq0m4ftTotRYtGnZd3eCztgbSPJ9QhfC91gDZQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -454,13 +507,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.4.tgz",
-      "integrity": "sha512-X3As2xhtgPTY/m5edUtddmZ8rCruvBvtxYLMw9OsZdH01L2gS2icsHRwxdU0dMItNfVmrBezueXZCHxVeeb7Aw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.11.tgz",
+      "integrity": "sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -470,13 +522,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.4.tgz",
-      "integrity": "sha512-2VG4DqhGaDSmYIu6C4ua2vSLXnJsb/C9liej7TuSO04NK+JJJgJucDUgmX6sn7Gw3Cs5ZJ9ZLrnI0QRDOjLfNQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.11.tgz",
+      "integrity": "sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -486,13 +537,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.4.tgz",
-      "integrity": "sha512-v+mxVgH2kmur/X5Mdrz9m7TsoVjbdYQT0b4Z+dr+I4RvreCNXyCFELZL/DO0M1RsidZTrm6O1eMnV6zlgEzTMQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.11.tgz",
+      "integrity": "sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -502,9 +552,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.4.tgz",
-      "integrity": "sha512-2TLe9ir+9esCf6Wm+lLWTMbgklIjiF0pbmDnwmhR9MksVOq+e8aP3TSsXySnBDDvTTVd/vKu1aNttEGj3P6l8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.11.tgz",
+      "integrity": "sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -516,13 +566,12 @@
       "cpu": [
         "wasm32"
       ],
-      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.0",
-        "@emnapi/runtime": "^1.4.0",
-        "@emnapi/wasi-threads": "^1.0.1",
-        "@napi-rs/wasm-runtime": "^0.2.8",
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@emnapi/wasi-threads": "^1.0.2",
+        "@napi-rs/wasm-runtime": "^0.2.11",
         "@tybys/wasm-util": "^0.9.0",
         "tslib": "^2.8.0"
       },
@@ -531,13 +580,12 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.4.tgz",
-      "integrity": "sha512-VlnhfilPlO0ltxW9/BgfLI5547PYzqBMPIzRrk4W7uupgCt8z6Trw/tAj6QUtF2om+1MH281Pg+HHUJoLesmng==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",
+      "integrity": "sha512-UgKYx5PwEKrac3GPNPf6HVMNhUIGuUh4wlDFR2jYYdkX6pL/rn73zTq/4pzUm8fOjAn5L8zDeHp9iXmUGOXZ+w==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -547,19 +595,26 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.4.tgz",
-      "integrity": "sha512-+7S63t5zhYjslUGb8NcgLpFXD+Kq1F/zt5Xv5qTv7HaFTG/DHyHD9GA6ieNAxhgyA4IcKa/zy7Xx4Oad2/wuhw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.11.tgz",
+      "integrity": "sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide/node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/braces": {
@@ -572,6 +627,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/detect-libc": {
@@ -587,10 +650,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
-      "license": "MIT",
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
+      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -614,8 +676,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -651,16 +712,14 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
-      "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
-      "license": "MPL-2.0",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -672,26 +731,25 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.29.2",
-        "lightningcss-darwin-x64": "1.29.2",
-        "lightningcss-freebsd-x64": "1.29.2",
-        "lightningcss-linux-arm-gnueabihf": "1.29.2",
-        "lightningcss-linux-arm64-gnu": "1.29.2",
-        "lightningcss-linux-arm64-musl": "1.29.2",
-        "lightningcss-linux-x64-gnu": "1.29.2",
-        "lightningcss-linux-x64-musl": "1.29.2",
-        "lightningcss-win32-arm64-msvc": "1.29.2",
-        "lightningcss-win32-x64-msvc": "1.29.2"
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.2.tgz",
-      "integrity": "sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -705,13 +763,12 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.2.tgz",
-      "integrity": "sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
       "cpu": [
         "x64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -725,13 +782,12 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.2.tgz",
-      "integrity": "sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
       "cpu": [
         "x64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -745,13 +801,12 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.2.tgz",
-      "integrity": "sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
       "cpu": [
         "arm"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -765,13 +820,12 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.2.tgz",
-      "integrity": "sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
       "cpu": [
         "arm64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -785,13 +839,12 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.2.tgz",
-      "integrity": "sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -805,13 +858,12 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
-      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
       "cpu": [
         "x64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -825,13 +877,12 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.2.tgz",
-      "integrity": "sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
       "cpu": [
         "x64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -845,13 +896,12 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.2.tgz",
-      "integrity": "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
       "cpu": [
         "arm64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -865,13 +915,12 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.2.tgz",
-      "integrity": "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
       "cpu": [
         "x64"
       ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -885,12 +934,19 @@
       }
     },
     "node_modules/lightningcss/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "license": "Apache-2.0",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/micromatch": {
@@ -904,6 +960,39 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mri": {
@@ -939,19 +1028,41 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tailwindcss": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.4.tgz",
-      "integrity": "sha512-1ZIUqtPITFbv/DxRmDr5/agPqJwF69d24m9qmM1939TJehgY539CtzeZRjbLt5G6fSy/7YqqYsfvoTEw9xUI2A==",
-      "license": "MIT"
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA=="
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-      "license": "MIT",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/to-regex-range": {
@@ -964,6 +1075,14 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
     "css": "tailwindcss -i input.css -o ./assets/main.css"
   },
   "dependencies": {
-    "@tailwindcss/cli": "^4.1.4",
-    "tailwindcss": "^4.1.4"
+    "@tailwindcss/cli": "^4.1.11",
+    "tailwindcss": "^4.1.11"
   }
 }

--- a/docs/src/components/animations.rs
+++ b/docs/src/components/animations.rs
@@ -2,7 +2,6 @@ use crate::components::code_block::CodeBlock;
 use dioxus::prelude::*;
 use dioxus_motion::{animations::core::Animatable, prelude::*};
 use easer::functions::Easing;
-use wide::f32x4;
 
 #[component]
 fn AnimationStep(title: String, description: String, code: String, children: Element) -> Element {
@@ -132,60 +131,56 @@ struct ColorValue {
     b: f32,
 }
 
-impl Animatable for ColorValue {
-    fn zero() -> Self {
+impl Default for ColorValue {
+    fn default() -> Self {
         ColorValue {
             r: 0.0,
             g: 0.0,
             b: 0.0,
         }
     }
+}
 
-    fn epsilon() -> f32 {
-        0.001
-    }
-
-    fn magnitude(&self) -> f32 {
-        (self.r * self.r + self.g * self.g + self.b * self.b).sqrt()
-    }
-
-    fn scale(&self, factor: f32) -> Self {
-        ColorValue {
-            r: (self.r * factor).clamp(0.0, 1.0),
-            g: (self.g * factor).clamp(0.0, 1.0),
-            b: (self.b * factor).clamp(0.0, 1.0),
-        }
-    }
-
-    fn add(&self, other: &Self) -> Self {
+impl std::ops::Add for ColorValue {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
         ColorValue {
             r: (self.r + other.r).clamp(0.0, 1.0),
             g: (self.g + other.g).clamp(0.0, 1.0),
             b: (self.b + other.b).clamp(0.0, 1.0),
         }
     }
+}
 
-    fn sub(&self, other: &Self) -> Self {
+impl std::ops::Sub for ColorValue {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
         ColorValue {
             r: (self.r - other.r).clamp(0.0, 1.0),
             g: (self.g - other.g).clamp(0.0, 1.0),
             b: (self.b - other.b).clamp(0.0, 1.0),
         }
     }
+}
 
-    fn interpolate(&self, target: &Self, t: f32) -> Self {
-        let a = [self.r, self.g, self.b, 0.0];
-        let b = [target.r, target.g, target.b, 0.0];
-        let va = f32x4::new(a);
-        let vb = f32x4::new(b);
-        let vt = f32x4::splat(t);
-        let result = va + (vb - va) * vt;
-        let out = result.to_array();
+impl std::ops::Mul<f32> for ColorValue {
+    type Output = Self;
+    fn mul(self, factor: f32) -> Self {
         ColorValue {
-            r: out[0],
-            g: out[1],
-            b: out[2],
+            r: (self.r * factor).clamp(0.0, 1.0),
+            g: (self.g * factor).clamp(0.0, 1.0),
+            b: (self.b * factor).clamp(0.0, 1.0),
         }
+    }
+}
+
+impl Animatable for ColorValue {
+    fn interpolate(&self, target: &Self, t: f32) -> Self {
+        *self + (*target - *self) * t
+    }
+
+    fn magnitude(&self) -> f32 {
+        (self.r * self.r + self.g * self.g + self.b * self.b).sqrt()
     }
 }
 
@@ -486,22 +481,54 @@ struct ColorValue {
     r: f32, g: f32, b: f32,
 }
 
-// Implement Animatable to enable animation
+// Implement standard Rust operator traits
+impl std::ops::Add for ColorValue {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        ColorValue {
+            r: (self.r + other.r).clamp(0.0, 1.0),
+            g: (self.g + other.g).clamp(0.0, 1.0),
+            b: (self.b + other.b).clamp(0.0, 1.0),
+        }
+    }
+}
+
+impl std::ops::Sub for ColorValue {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        ColorValue {
+            r: (self.r - other.r).clamp(0.0, 1.0),
+            g: (self.g - other.g).clamp(0.0, 1.0),
+            b: (self.b - other.b).clamp(0.0, 1.0),
+        }
+    }
+}
+
+impl std::ops::Mul<f32> for ColorValue {
+    type Output = Self;
+    fn mul(self, factor: f32) -> Self {
+        ColorValue {
+            r: (self.r * factor).clamp(0.0, 1.0),
+            g: (self.g * factor).clamp(0.0, 1.0),
+            b: (self.b * factor).clamp(0.0, 1.0),
+        }
+    }
+}
+
+impl Default for ColorValue {
+    fn default() -> Self {
+        ColorValue { r: 0.0, g: 0.0, b: 0.0 }
+    }
+}
+
+// Implement Animatable with only 2 required methods
 impl Animatable for ColorValue {
-    fn zero() -> Self { ColorValue { r: 0.0, g: 0.0, b: 0.0 } }
-    fn epsilon() -> f32 { 0.001 }
+    fn interpolate(&self, target: &Self, t: f32) -> Self {
+        *self + (*target - *self) * t
+    }
+    
     fn magnitude(&self) -> f32 {
         (self.r * self.r + self.g * self.g + self.b * self.b).sqrt()
-    }
-    fn interpolate(&self, target: &Self, t: f32) -> Self {
-        let a = [self.r, self.g, self.b, 0.0];
-        let b = [target.r, target.g, target.b, 0.0];
-        let va = f32x4::new(a);
-        let vb = f32x4::new(b);
-        let vt = f32x4::splat(t);
-        let result = va + (vb - va) * vt;
-        let out = result.to_array();
-        ColorValue { r: out[0], g: out[1], b: out[2] }
     }
 }
 

--- a/docs/src/old_showcase/components/animated_flower.rs
+++ b/docs/src/old_showcase/components/animated_flower.rs
@@ -22,33 +22,15 @@ impl PetalTransform {
     }
 }
 
-impl Animatable for PetalTransform {
-    fn zero() -> Self {
+impl Default for PetalTransform {
+    fn default() -> Self {
         Self::new(0.0, 0.0, 0.0, 0.0)
     }
+}
 
-    fn epsilon() -> f32 {
-        0.001
-    }
-
-    fn magnitude(&self) -> f32 {
-        (self.rotate * self.rotate
-            + self.scale * self.scale
-            + self.translate_x * self.translate_x
-            + self.translate_y * self.translate_y)
-            .sqrt()
-    }
-
-    fn scale(&self, factor: f32) -> Self {
-        Self::new(
-            self.rotate * factor,
-            self.scale * factor,
-            self.translate_x * factor,
-            self.translate_y * factor,
-        )
-    }
-
-    fn add(&self, other: &Self) -> Self {
+impl std::ops::Add for PetalTransform {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
         Self::new(
             self.rotate + other.rotate,
             self.scale + other.scale,
@@ -56,8 +38,11 @@ impl Animatable for PetalTransform {
             self.translate_y + other.translate_y,
         )
     }
+}
 
-    fn sub(&self, other: &Self) -> Self {
+impl std::ops::Sub for PetalTransform {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
         Self::new(
             self.rotate - other.rotate,
             self.scale - other.scale,
@@ -65,7 +50,21 @@ impl Animatable for PetalTransform {
             self.translate_y - other.translate_y,
         )
     }
+}
 
+impl std::ops::Mul<f32> for PetalTransform {
+    type Output = Self;
+    fn mul(self, factor: f32) -> Self {
+        Self::new(
+            self.rotate * factor,
+            self.scale * factor,
+            self.translate_x * factor,
+            self.translate_y * factor,
+        )
+    }
+}
+
+impl Animatable for PetalTransform {
     fn interpolate(&self, target: &Self, t: f32) -> Self {
         let a = [self.rotate, self.scale, self.translate_x, self.translate_y];
         let b = [
@@ -81,12 +80,20 @@ impl Animatable for PetalTransform {
         let out = result.to_array();
         PetalTransform::new(out[0], out[1], out[2], out[3])
     }
+
+    fn magnitude(&self) -> f32 {
+        (self.rotate * self.rotate
+            + self.scale * self.scale
+            + self.translate_x * self.translate_x
+            + self.translate_y * self.translate_y)
+            .sqrt()
+    }
 }
 
 #[component]
 pub fn AnimatedFlower() -> Element {
-    let mut petal_transform = use_motion(PetalTransform::zero());
-    let mut leaf_transform = use_motion(PetalTransform::zero());
+    let mut petal_transform = use_motion(PetalTransform::default());
+    let mut leaf_transform = use_motion(PetalTransform::default());
     let mut center_scale = use_motion(1.0f32); // Start from 1.0 instead of 0.0
     let mut center_rotate = use_motion(0.0f32);
     let mut is_leaves_grown = use_signal_sync(|| false);

--- a/docs/src/old_showcase/components/cube_animation.rs
+++ b/docs/src/old_showcase/components/cube_animation.rs
@@ -33,37 +33,15 @@ impl Transform3D {
     }
 }
 
-impl Animatable for Transform3D {
-    fn zero() -> Self {
+impl Default for Transform3D {
+    fn default() -> Self {
         Self::new(0.0, 0.0, 0.0, 0.0, 0.0, 1.0)
     }
+}
 
-    fn epsilon() -> f32 {
-        0.001
-    }
-
-    fn magnitude(&self) -> f32 {
-        (self.rotate_x * self.rotate_x
-            + self.rotate_y * self.rotate_y
-            + self.rotate_z * self.rotate_z
-            + self.translate_x * self.translate_x
-            + self.translate_y * self.translate_y
-            + self.scale * self.scale)
-            .sqrt()
-    }
-
-    fn scale(&self, factor: f32) -> Self {
-        Self::new(
-            self.rotate_x * factor,
-            self.rotate_y * factor,
-            self.rotate_z * factor,
-            self.translate_x * factor,
-            self.translate_y * factor,
-            self.scale * factor,
-        )
-    }
-
-    fn add(&self, other: &Self) -> Self {
+impl std::ops::Add for Transform3D {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
         Self::new(
             self.rotate_x + other.rotate_x,
             self.rotate_y + other.rotate_y,
@@ -73,8 +51,11 @@ impl Animatable for Transform3D {
             self.scale + other.scale,
         )
     }
+}
 
-    fn sub(&self, other: &Self) -> Self {
+impl std::ops::Sub for Transform3D {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
         Self::new(
             self.rotate_x - other.rotate_x,
             self.rotate_y - other.rotate_y,
@@ -84,7 +65,23 @@ impl Animatable for Transform3D {
             self.scale - other.scale,
         )
     }
+}
 
+impl std::ops::Mul<f32> for Transform3D {
+    type Output = Self;
+    fn mul(self, factor: f32) -> Self {
+        Self::new(
+            self.rotate_x * factor,
+            self.rotate_y * factor,
+            self.rotate_z * factor,
+            self.translate_x * factor,
+            self.translate_y * factor,
+            self.scale * factor,
+        )
+    }
+}
+
+impl Animatable for Transform3D {
     fn interpolate(&self, target: &Self, t: f32) -> Self {
         // SIMD for the first 4 fields
         let a1 = [
@@ -112,6 +109,16 @@ impl Animatable for Transform3D {
         let result2 = va2 + (vb2 - va2) * vt;
         let out2 = result2.to_array();
         Self::new(out1[0], out1[1], out1[2], out1[3], out2[0], out2[1])
+    }
+
+    fn magnitude(&self) -> f32 {
+        (self.rotate_x * self.rotate_x
+            + self.rotate_y * self.rotate_y
+            + self.rotate_z * self.rotate_z
+            + self.translate_x * self.translate_x
+            + self.translate_y * self.translate_y
+            + self.scale * self.scale)
+            .sqrt()
     }
 }
 
@@ -218,7 +225,7 @@ const FACES: [[usize; 4]; 6] = [
 
 #[component]
 pub fn SwingingCube() -> Element {
-    let mut transform = use_motion(Transform3D::zero());
+    let mut transform = use_motion(Transform3D::default());
     let mut glow_scale = use_motion(1.0f32);
     let mut pulse_scale = use_motion(1.0f32);
     let mut highlight_opacity = use_motion(0.0f32);

--- a/docs/src/old_showcase/components/rotating_button.rs
+++ b/docs/src/old_showcase/components/rotating_button.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use dioxus_motion::prelude::*;
+use dioxus_motion::{KeyframeAnimation, prelude::*};
 use easer::functions::Easing;
 
 // A playful button that bounces on click
@@ -10,58 +10,37 @@ pub fn RotatingButton() -> Element {
     let mut glow = use_motion(0.0f32);
 
     let onclick = move |_| {
-        // Optimized scale sequence with better physics and smoother transitions
-        let scale_sequence = AnimationSequence::new()
-            .then(
-                1.15, // Reduced maximum scale for snappier feel
-                AnimationConfig::new(AnimationMode::Spring(Spring {
-                    stiffness: 500.0, // Increased stiffness for faster response
-                    damping: 15.0,    // Balanced damping for controlled bounce
-                    mass: 0.8,        // Lighter mass for quicker movement
-                    velocity: 8.0,    // Increased initial velocity
-                })),
-            )
-            .then(
-                0.9, // Subtle scale down
-                AnimationConfig::new(AnimationMode::Spring(Spring {
-                    stiffness: 400.0,
-                    damping: 12.0,
-                    mass: 0.6,
-                    velocity: -4.0, // Negative velocity for natural rebound
-                })),
-            )
-            .then(
-                1.0, // Return to original size
-                AnimationConfig::new(AnimationMode::Spring(Spring {
-                    stiffness: 350.0,
-                    damping: 20.0, // Higher damping for smooth finish
-                    mass: 0.7,
-                    velocity: 0.0,
-                })),
-            );
+        // Smooth scale keyframe animation for bounce effect
+        let scale_keyframes = KeyframeAnimation::new(Duration::from_millis(800))
+            .add_keyframe(1.0, 0.0, Some(easer::functions::Expo::ease_out)) // Start
+            .unwrap()
+            .add_keyframe(1.15, 0.3, Some(easer::functions::Back::ease_out)) // Peak scale
+            .unwrap()
+            .add_keyframe(0.95, 0.7, Some(easer::functions::Bounce::ease_out)) // Slight undershoot
+            .unwrap()
+            .add_keyframe(1.0, 1.0, Some(easer::functions::Elastic::ease_out)); // Final rest
 
-        // Optimized rotation with smoother easing
-        let rotation_sequence = AnimationSequence::new().then(
-            360.0,
-            AnimationConfig::new(AnimationMode::Tween(Tween {
-                duration: Duration::from_millis(800),     // Faster rotation
-                easing: easer::functions::Expo::ease_out, // Smoother deceleration
-            })),
-        );
+        // Smooth rotation keyframe animation
+        let rotation_keyframes = KeyframeAnimation::new(Duration::from_millis(800))
+            .add_keyframe(0.0, 0.0, Some(easer::functions::Cubic::ease_in_out)) // Start
+            .unwrap()
+            .add_keyframe(180.0, 0.5, Some(easer::functions::Expo::ease_in_out)) // Half rotation
+            .unwrap()
+            .add_keyframe(360.0, 1.0, Some(easer::functions::Back::ease_out)); // Full rotation with overshoot
 
-        // Quick glow effect
-        glow.animate_to(
-            1.0,
-            AnimationConfig::new(AnimationMode::Spring(Spring {
-                stiffness: 450.0,
-                damping: 15.0,
-                mass: 0.5,
-                velocity: 10.0,
-            })),
-        );
+        // Quick glow effect with keyframes
+        let glow_keyframes = KeyframeAnimation::new(Duration::from_millis(600))
+            .add_keyframe(0.0, 0.0, Some(easer::functions::Quart::ease_out)) // Start
+            .unwrap()
+            .add_keyframe(1.0, 0.2, Some(easer::functions::Expo::ease_out)) // Peak glow
+            .unwrap()
+            .add_keyframe(0.3, 0.6, Some(easer::functions::Cubic::ease_in_out)) // Fade
+            .unwrap()
+            .add_keyframe(0.0, 1.0, Some(easer::functions::Quart::ease_in)); // Fade out
 
-        scale.animate_sequence(scale_sequence);
-        rotation.animate_sequence(rotation_sequence);
+        scale.animate_keyframes(scale_keyframes.unwrap());
+        rotation.animate_keyframes(rotation_keyframes.unwrap());
+        glow.animate_keyframes(glow_keyframes.unwrap());
     };
 
     rsx! {

--- a/docs/src/old_showcase/components/rotating_button.rs
+++ b/docs/src/old_showcase/components/rotating_button.rs
@@ -2,6 +2,18 @@ use dioxus::prelude::*;
 use dioxus_motion::{KeyframeAnimation, prelude::*};
 use easer::functions::Easing;
 
+// Helper function to safely build keyframe animations
+fn build_keyframes<T: dioxus_motion::animations::core::Animatable>(
+    duration: Duration,
+    keyframes: Vec<(T, f32, Option<fn(f32, f32, f32, f32) -> f32>)>,
+) -> Result<KeyframeAnimation<T>, dioxus_motion::keyframes::KeyframeError> {
+    let mut animation = KeyframeAnimation::new(duration);
+    for (value, offset, easing) in keyframes {
+        animation = animation.add_keyframe(value, offset, easing)?;
+    }
+    Ok(animation)
+}
+
 // A playful button that bounces on click
 #[component]
 pub fn RotatingButton() -> Element {
@@ -11,36 +23,47 @@ pub fn RotatingButton() -> Element {
 
     let onclick = move |_| {
         // Smooth scale keyframe animation for bounce effect
-        let scale_keyframes = KeyframeAnimation::new(Duration::from_millis(800))
-            .add_keyframe(1.0, 0.0, Some(easer::functions::Expo::ease_out)) // Start
-            .unwrap()
-            .add_keyframe(1.15, 0.3, Some(easer::functions::Back::ease_out)) // Peak scale
-            .unwrap()
-            .add_keyframe(0.95, 0.7, Some(easer::functions::Bounce::ease_out)) // Slight undershoot
-            .unwrap()
-            .add_keyframe(1.0, 1.0, Some(easer::functions::Elastic::ease_out)); // Final rest
+        let scale_keyframes = build_keyframes(
+            Duration::from_millis(800),
+            vec![
+                (1.0, 0.0, Some(easer::functions::Expo::ease_out)), // Start
+                (1.15, 0.3, Some(easer::functions::Back::ease_out)), // Peak scale
+                (0.95, 0.7, Some(easer::functions::Bounce::ease_out)), // Slight undershoot
+                (1.0, 1.0, Some(easer::functions::Elastic::ease_out)), // Final rest
+            ],
+        );
 
         // Smooth rotation keyframe animation
-        let rotation_keyframes = KeyframeAnimation::new(Duration::from_millis(800))
-            .add_keyframe(0.0, 0.0, Some(easer::functions::Cubic::ease_in_out)) // Start
-            .unwrap()
-            .add_keyframe(180.0, 0.5, Some(easer::functions::Expo::ease_in_out)) // Half rotation
-            .unwrap()
-            .add_keyframe(360.0, 1.0, Some(easer::functions::Back::ease_out)); // Full rotation with overshoot
+        let rotation_keyframes = build_keyframes(
+            Duration::from_millis(800),
+            vec![
+                (0.0, 0.0, Some(easer::functions::Cubic::ease_in_out)), // Start
+                (180.0, 0.5, Some(easer::functions::Expo::ease_in_out)), // Half rotation
+                (360.0, 1.0, Some(easer::functions::Back::ease_out)), // Full rotation with overshoot
+            ],
+        );
 
         // Quick glow effect with keyframes
-        let glow_keyframes = KeyframeAnimation::new(Duration::from_millis(600))
-            .add_keyframe(0.0, 0.0, Some(easer::functions::Quart::ease_out)) // Start
-            .unwrap()
-            .add_keyframe(1.0, 0.2, Some(easer::functions::Expo::ease_out)) // Peak glow
-            .unwrap()
-            .add_keyframe(0.3, 0.6, Some(easer::functions::Cubic::ease_in_out)) // Fade
-            .unwrap()
-            .add_keyframe(0.0, 1.0, Some(easer::functions::Quart::ease_in)); // Fade out
+        let glow_keyframes = build_keyframes(
+            Duration::from_millis(600),
+            vec![
+                (0.0, 0.0, Some(easer::functions::Quart::ease_out)), // Start
+                (1.0, 0.2, Some(easer::functions::Expo::ease_out)),  // Peak glow
+                (0.3, 0.6, Some(easer::functions::Cubic::ease_in_out)), // Fade
+                (0.0, 1.0, Some(easer::functions::Quart::ease_in)),  // Fade out
+            ],
+        );
 
-        scale.animate_keyframes(scale_keyframes.unwrap());
-        rotation.animate_keyframes(rotation_keyframes.unwrap());
-        glow.animate_keyframes(glow_keyframes.unwrap());
+        // Only animate if keyframe creation succeeded
+        if let Ok(scale_anim) = scale_keyframes {
+            scale.animate_keyframes(scale_anim);
+        }
+        if let Ok(rotation_anim) = rotation_keyframes {
+            rotation.animate_keyframes(rotation_anim);
+        }
+        if let Ok(glow_anim) = glow_keyframes {
+            glow.animate_keyframes(glow_anim);
+        }
     };
 
     rsx! {

--- a/docs/src/pages/complex_guide.rs
+++ b/docs/src/pages/complex_guide.rs
@@ -15,15 +15,6 @@ struct PetalTransform {
 }
 
 impl PetalTransform {
-    fn zero() -> Self {
-        Self {
-            rotate: 0.0,
-            scale: 0.0,
-            translate_x: 0.0,
-            translate_y: 0.0,
-        }
-    }
-
     fn new(rotate: f32, scale: f32, translate_x: f32, translate_y: f32) -> Self {
         Self {
             rotate,
@@ -59,13 +50,37 @@ impl std::ops::Add for PetalTransform {
     }
 }
 
-impl dioxus_motion::animations::core::Animatable for PetalTransform {
-    fn zero() -> Self {
-        Self::zero()
+impl Default for PetalTransform {
+    fn default() -> Self {
+        Self {
+            rotate: 0.0,
+            scale: 1.0, // Default scale to 1.0 for identity
+            translate_x: 0.0,
+            translate_y: 0.0,
+        }
     }
+}
 
-    fn epsilon() -> f32 {
-        dioxus_motion::animations::epsilon::DEFAULT_EPSILON
+impl std::ops::Sub for PetalTransform {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            rotate: self.rotate - rhs.rotate,
+            scale: self.scale - rhs.scale,
+            translate_x: self.translate_x - rhs.translate_x,
+            translate_y: self.translate_y - rhs.translate_y,
+        }
+    }
+}
+
+impl dioxus_motion::animations::core::Animatable for PetalTransform {
+    fn interpolate(&self, other: &Self, t: f32) -> Self {
+        Self::new(
+            self.rotate + (other.rotate - self.rotate) * t,
+            self.scale + (other.scale - self.scale) * t,
+            self.translate_x + (other.translate_x - self.translate_x) * t,
+            self.translate_y + (other.translate_y - self.translate_y) * t,
+        )
     }
 
     fn magnitude(&self) -> f32 {
@@ -76,41 +91,7 @@ impl dioxus_motion::animations::core::Animatable for PetalTransform {
             .sqrt()
     }
 
-    fn scale(&self, factor: f32) -> Self {
-        Self::new(
-            self.rotate * factor,
-            self.scale * factor,
-            self.translate_x * factor,
-            self.translate_y * factor,
-        )
-    }
-
-    fn add(&self, other: &Self) -> Self {
-        Self::new(
-            self.rotate + other.rotate,
-            self.scale + other.scale,
-            self.translate_x + other.translate_x,
-            self.translate_y + other.translate_y,
-        )
-    }
-
-    fn sub(&self, other: &Self) -> Self {
-        Self::new(
-            self.rotate - other.rotate,
-            self.scale - other.scale,
-            self.translate_x - other.translate_x,
-            self.translate_y - other.translate_y,
-        )
-    }
-
-    fn interpolate(&self, other: &Self, t: f32) -> Self {
-        Self::new(
-            self.rotate + (other.rotate - self.rotate) * t,
-            self.scale + (other.scale - self.scale) * t,
-            self.translate_x + (other.translate_x - self.translate_x) * t,
-            self.translate_y + (other.translate_y - self.translate_y) * t,
-        )
-    }
+    // Uses default epsilon of 0.01 from the trait
 }
 
 #[component]
@@ -204,12 +185,13 @@ impl std::ops::Add for PetalTransform {
 }
 
 impl dioxus_motion::animations::core::Animatable for PetalTransform {
-    fn zero() -> Self {
-        Self::zero()
-    }
-
-    fn epsilon() -> f32 {
-        dioxus_motion::animations::epsilon::DEFAULT_EPSILON
+    fn interpolate(&self, other: &Self, t: f32) -> Self {
+        Self::new(
+            self.rotate + (other.rotate - self.rotate) * t,
+            self.scale + (other.scale - self.scale) * t,
+            self.translate_x + (other.translate_x - self.translate_x) * t,
+            self.translate_y + (other.translate_y - self.translate_y) * t,
+        )
     }
 
     fn magnitude(&self) -> f32 {
@@ -220,41 +202,31 @@ impl dioxus_motion::animations::core::Animatable for PetalTransform {
             .sqrt()
     }
 
-    fn scale(&self, factor: f32) -> Self {
-        Self::new(
-            self.rotate * factor,
-            self.scale * factor,
-            self.translate_x * factor,
-            self.translate_y * factor,
-        )
-    }
+    // Uses default epsilon of 0.01 from the trait
+}
 
-    fn add(&self, other: &Self) -> Self {
-        Self::new(
-            self.rotate + other.rotate,
-            self.scale + other.scale,
-            self.translate_x + other.translate_x,
-            self.translate_y + other.translate_y,
-        )
+impl Default for PetalTransform {
+    fn default() -> Self {
+        Self {
+            rotate: 0.0,
+            scale: 1.0, // Default scale to 1.0 for identity
+            translate_x: 0.0,
+            translate_y: 0.0,
+        }
     }
+}
 
-    fn sub(&self, other: &Self) -> Self {
-        Self::new(
-            self.rotate - other.rotate,
-            self.scale - other.scale,
-            self.translate_x - other.translate_x,
-            self.translate_y - other.translate_y,
-        )
+impl std::ops::Sub for PetalTransform {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            rotate: self.rotate - rhs.rotate,
+            scale: self.scale - rhs.scale,
+            translate_x: self.translate_x - rhs.translate_x,
+            translate_y: self.translate_y - rhs.translate_y,
+        }
     }
-
-    fn interpolate(&self, other: &Self, t: f32) -> Self {
-        Self::new(
-            self.rotate + (other.rotate - self.rotate) * t,
-            self.scale + (other.scale - self.scale) * t,
-            self.translate_x + (other.translate_x - self.translate_x) * t,
-            self.translate_y + (other.translate_y - self.translate_y) * t,
-        )
-    }
+}
 }"#.to_string(),
                         language: "rust".to_string(),
                     }
@@ -277,7 +249,7 @@ impl dioxus_motion::animations::core::Animatable for PetalTransform {
 
 #[component]
 fn StepTwo() -> Element {
-    let mut petal = use_motion(PetalTransform::zero());
+    let mut petal = use_motion(PetalTransform::default());
 
     let animate = move |_| {
         petal.animate_to(
@@ -293,7 +265,7 @@ fn StepTwo() -> Element {
 
     let reset = move |_| {
         petal.animate_to(
-            PetalTransform::zero(),
+            PetalTransform::default(),
             AnimationConfig::new(AnimationMode::Spring(Spring::default())),
         );
     };
@@ -311,7 +283,7 @@ fn StepTwo() -> Element {
                 // Code example
                 div { class: "bg-dark-200/50 p-3 rounded-lg",
                     CodeBlock {
-                        code: r#"let mut petal = use_motion(PetalTransform::zero());
+                        code: r#"let mut petal = use_motion(PetalTransform::default());
 
 // Animate to new values
 petal.animate_to(
@@ -372,7 +344,7 @@ petal.animate_to(
 
 #[component]
 fn StepThree() -> Element {
-    let mut petal = use_motion(PetalTransform::zero());
+    let mut petal = use_motion(PetalTransform::default());
 
     let animate_sequence = move |_| {
         let sequence = AnimationSequence::new()
@@ -395,7 +367,7 @@ fn StepThree() -> Element {
                 })),
             )
             .then(
-                PetalTransform::zero(),
+                PetalTransform::default(),
                 AnimationConfig::new(AnimationMode::Spring(Spring {
                     stiffness: 200.0,
                     damping: 15.0,
@@ -410,7 +382,7 @@ fn StepThree() -> Element {
     let animate_keyframes = move |_| {
         let keyframes = KeyframeAnimation::new(Duration::from_secs(2))
             .add_keyframe(
-                PetalTransform::zero(),
+                PetalTransform::default(),
                 0.0,
                 Some(easer::functions::Cubic::ease_in),
             )
@@ -430,7 +402,7 @@ fn StepThree() -> Element {
             })
             .and_then(|kf| {
                 kf.add_keyframe(
-                    PetalTransform::zero(),
+                    PetalTransform::default(),
                     1.0,
                     Some(easer::functions::Back::ease_in_out),
                 )
@@ -464,7 +436,7 @@ fn StepThree() -> Element {
         spring_config.clone(),
     )
     .then(
-        PetalTransform::zero(),
+        PetalTransform::default(),
         spring_config,
     );
 

--- a/docs/src/pages/complex_guide.rs
+++ b/docs/src/pages/complex_guide.rs
@@ -54,7 +54,7 @@ impl Default for PetalTransform {
     fn default() -> Self {
         Self {
             rotate: 0.0,
-            scale: 1.0, // Default scale to 1.0 for identity
+            scale: 0.0, // Start invisible, consistent with animated_flower.rs
             translate_x: 0.0,
             translate_y: 0.0,
         }
@@ -209,7 +209,7 @@ impl Default for PetalTransform {
     fn default() -> Self {
         Self {
             rotate: 0.0,
-            scale: 1.0, // Default scale to 1.0 for identity
+            scale: 0.0, // Start invisible, consistent with animated_flower.rs
             translate_x: 0.0,
             translate_y: 0.0,
         }

--- a/src/animations/core.rs
+++ b/src/animations/core.rs
@@ -8,32 +8,31 @@ use std::sync::{Arc, Mutex};
 use crate::animations::{spring::Spring, tween::Tween};
 use instant::Duration;
 
-/// A trait for types that can be animated
+/// A simplified trait for types that can be animated
 ///
-/// Types implementing this trait can be used with both tween and spring animations.
-/// The trait provides basic mathematical operations needed for interpolation and
-/// physics calculations.
-pub trait Animatable: Copy + 'static {
-    /// Creates a zero value for the type
-    fn zero() -> Self;
-
-    /// Returns the smallest meaningful difference between values
-    fn epsilon() -> f32;
-
-    /// Calculates the magnitude/length of the value
-    fn magnitude(&self) -> f32;
-
-    /// Scales the value by a factor
-    fn scale(&self, factor: f32) -> Self;
-
-    /// Adds another value
-    fn add(&self, other: &Self) -> Self;
-
-    /// Subtracts another value
-    fn sub(&self, other: &Self) -> Self;
-
+/// This trait leverages standard Rust operator traits for mathematical operations,
+/// reducing boilerplate and making implementations more intuitive.
+/// Only requires implementing interpolation and magnitude calculation.
+pub trait Animatable:
+    Copy
+    + 'static
+    + Default
+    + std::ops::Add<Output = Self>
+    + std::ops::Sub<Output = Self>
+    + std::ops::Mul<f32, Output = Self>
+{
     /// Interpolates between self and target using t (0.0 to 1.0)
     fn interpolate(&self, target: &Self, t: f32) -> Self;
+
+    /// Calculates the magnitude/distance from zero
+    /// Used for determining animation completion
+    fn magnitude(&self) -> f32;
+
+    /// Returns the epsilon threshold for this type
+    /// Default implementation provides a reasonable value for most use cases
+    fn epsilon() -> f32 {
+        0.01 // Single default epsilon for simplicity
+    }
 }
 
 /// Defines the type of animation to be used

--- a/src/animations/epsilon.rs
+++ b/src/animations/epsilon.rs
@@ -1,87 +1,7 @@
-//! Epsilon constants for animation precision control
+//! Epsilon utilities for animation precision control
 //!
-//! This module provides standardized epsilon values for different animation types.
-//! Using consistent epsilon values ensures that animations complete synchronously
-//! and provides predictable timing behavior across all animation systems.
-
-/// High precision epsilon for color animations
-///
-/// Colors require high precision due to their visual sensitivity.
-/// Small color differences can be perceptible, so we use a tight epsilon
-/// to ensure smooth, high-quality color transitions.
-pub const COLOR_EPSILON: f32 = 0.0001;
-
-/// Standard precision epsilon for basic numeric animations
-///
-/// This is the default epsilon for most animation types including
-/// basic numeric values, coordinates, and simple transformations.
-/// Provides a good balance between precision and performance.
-pub const DEFAULT_EPSILON: f32 = 0.001;
-
-/// Medium precision epsilon for transform animations
-///
-/// Transform animations (translation, rotation, scale) can tolerate
-/// slightly less precision since small pixel differences are often
-/// imperceptible at typical screen resolutions.
-pub const TRANSFORM_EPSILON: f32 = 0.005;
-
-/// Low precision epsilon for page transitions
-///
-/// Page transitions involve larger movements and can use lower precision
-/// for better performance. The visual impact of small differences is
-/// minimal when transitioning between full pages.
-pub const PAGE_TRANSITION_EPSILON: f32 = 0.01;
-
-/// Ultra-high precision epsilon for specialized animations
-///
-/// Reserved for animations that require maximum precision,
-/// such as mathematical visualizations or high-precision graphics.
-pub const ULTRA_HIGH_PRECISION_EPSILON: f32 = 0.00001;
-
-/// Gets the appropriate epsilon for an animation type
-///
-/// This function can be used to select the right epsilon value
-/// based on the animation context or type.
-///
-/// # Examples
-/// ```rust
-/// use dioxus_motion::animations::epsilon::*;
-///
-/// // For color animations
-/// let color_eps = get_epsilon_for_type(AnimationTypeHint::Color);
-/// assert_eq!(color_eps, COLOR_EPSILON);
-///
-/// // For transform animations  
-/// let transform_eps = get_epsilon_for_type(AnimationTypeHint::Transform);
-/// assert_eq!(transform_eps, TRANSFORM_EPSILON);
-/// ```
-pub fn get_epsilon_for_type(animation_type: AnimationTypeHint) -> f32 {
-    match animation_type {
-        AnimationTypeHint::Color => COLOR_EPSILON,
-        AnimationTypeHint::Transform => TRANSFORM_EPSILON,
-        AnimationTypeHint::PageTransition => PAGE_TRANSITION_EPSILON,
-        AnimationTypeHint::UltraHighPrecision => ULTRA_HIGH_PRECISION_EPSILON,
-        AnimationTypeHint::Default => DEFAULT_EPSILON,
-    }
-}
-
-/// Hint for selecting appropriate epsilon values
-///
-/// This enum helps select the right epsilon value for different
-/// animation contexts, ensuring consistent precision across the system.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum AnimationTypeHint {
-    /// Default numeric animations
-    Default,
-    /// Color animations requiring high precision
-    Color,
-    /// Transform animations (translation, rotation, scale)
-    Transform,
-    /// Page transition animations
-    PageTransition,
-    /// Ultra-high precision animations for specialized use cases
-    UltraHighPrecision,
-}
+//! With the simplified Animatable trait, most animations use a single default epsilon (0.01).
+//! This module provides validation utilities for custom epsilon values.
 
 /// Validates that an epsilon value is within reasonable bounds
 ///
@@ -94,6 +14,15 @@ pub enum AnimationTypeHint {
 /// # Returns
 /// * `Ok(())` if the epsilon is valid
 /// * `Err(String)` with an error message if invalid
+///
+/// # Examples
+/// ```rust
+/// use dioxus_motion::animations::epsilon::validate_epsilon;
+///
+/// assert!(validate_epsilon(0.01).is_ok());
+/// assert!(validate_epsilon(0.0).is_err());
+/// assert!(validate_epsilon(0.2).is_err());
+/// ```
 pub fn validate_epsilon(epsilon: f32) -> Result<(), String> {
     if epsilon <= 0.0 {
         return Err("Epsilon must be positive".to_string());
@@ -115,67 +44,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_epsilon_constants() {
-        // These constants are defined with specific ordering by design:
-        // ULTRA_HIGH_PRECISION_EPSILON (0.00001) < COLOR_EPSILON (0.0001) < DEFAULT_EPSILON (0.001) < TRANSFORM_EPSILON (0.005) < PAGE_TRANSITION_EPSILON (0.01)
-
-        // Test that all constants are within reasonable bounds by validating them
-        assert!(validate_epsilon(COLOR_EPSILON).is_ok());
-        assert!(validate_epsilon(DEFAULT_EPSILON).is_ok());
-        assert!(validate_epsilon(TRANSFORM_EPSILON).is_ok());
-        assert!(validate_epsilon(PAGE_TRANSITION_EPSILON).is_ok());
-        assert!(validate_epsilon(ULTRA_HIGH_PRECISION_EPSILON).is_ok());
-
-        // Test that the get_epsilon_for_type function works correctly
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::Color),
-            COLOR_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::Default),
-            DEFAULT_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::Transform),
-            TRANSFORM_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::PageTransition),
-            PAGE_TRANSITION_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::UltraHighPrecision),
-            ULTRA_HIGH_PRECISION_EPSILON
-        );
-    }
-
-    #[test]
-    fn test_get_epsilon_for_type() {
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::Color),
-            COLOR_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::Transform),
-            TRANSFORM_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::PageTransition),
-            PAGE_TRANSITION_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::Default),
-            DEFAULT_EPSILON
-        );
-        assert_eq!(
-            get_epsilon_for_type(AnimationTypeHint::UltraHighPrecision),
-            ULTRA_HIGH_PRECISION_EPSILON
-        );
-    }
-
-    #[test]
     fn test_validate_epsilon() {
         assert!(validate_epsilon(0.001).is_ok());
+        assert!(validate_epsilon(0.01).is_ok());
+        assert!(validate_epsilon(0.1).is_ok());
+
         assert!(validate_epsilon(0.0).is_err());
         assert!(validate_epsilon(-0.001).is_err());
         assert!(validate_epsilon(0.000001).is_err());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified the `Animatable` trait to require only `interpolate()` and `magnitude()` methods, leveraging standard Rust operator traits and `Default` for arithmetic and initialization.
  * Introduced a single default epsilon value (0.01) for animation completion detection.

* **Refactor**
  * Updated all built-in and custom animatable types to use standard Rust operators and the new trait requirements.
  * Replaced custom arithmetic and zero-value methods with operator overloading and `Default` across the codebase.
  * Refactored animation definitions to use keyframes and easing functions for smoother effects.

* **Bug Fixes**
  * Streamlined epsilon validation to focus on a single value, removing outdated constants and logic.

* **Documentation**
  * Enhanced documentation and examples to reflect the simplified trait, new usage patterns, and migration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->