### PR TITLE
Add support for Tween-based page transitions

### DIFF
--- a/docs/src/components/page_transition.rs
+++ b/docs/src/components/page_transition.rs
@@ -554,8 +554,9 @@ enum Route {
                     CodeBlock {
                         code: r#"use dioxus_motion::transitions::page_transitions::TransitionVariantResolver;
 
+// NOTE: Route::Card { idx } is a hypothetical example variant for illustration purposes.
+// Replace with your actual route variants as needed.
 let resolver: TransitionVariantResolver<Route> = std::rc::Rc::new(|from, to| {
-    // Assuming Route::Card { idx } for cards
     match (from, to) {
         (Route::Card { idx: from_idx }, Route::Card { idx: to_idx }) => {
             if to_idx > from_idx {

--- a/docs/src/components/page_transition.rs
+++ b/docs/src/components/page_transition.rs
@@ -540,6 +540,44 @@ enum Route {
                 }
             }
 
+            // Dynamic Transition Resolver Example
+            section {
+                h2 { class: "text-2xl font-semibold text-text-primary", "Dynamic Transition Direction" }
+                p { class: "text-text-secondary mb-4",
+                    "You can dynamically choose the transition direction based on navigation context. For example, in a card navigation UI, you may want to slide left or right depending on which card the user is moving to."
+                }
+                div { class: "bg-dark-200/50 backdrop-blur-xs rounded-xl p-6 border border-primary/10 mb-6",
+                    h3 { class: "text-lg font-medium text-text-primary mb-4", "How to Provide a Dynamic Resolver" }
+                    p { class: "text-text-secondary mb-4",
+                        "Provide a resolver function via context that receives the previous and next route, and returns the appropriate transition variant."
+                    }
+                    CodeBlock {
+                        code: r#"use dioxus_motion::transitions::page_transitions::TransitionVariantResolver;
+
+let resolver: TransitionVariantResolver<Route> = std::rc::Rc::new(|from, to| {
+    // Assuming Route::Card { idx } for cards
+    match (from, to) {
+        (Route::Card { idx: from_idx }, Route::Card { idx: to_idx }) => {
+            if to_idx > from_idx {
+                TransitionVariant::SlideLeft
+            } else if to_idx < from_idx {
+                TransitionVariant::SlideRight
+            } else {
+                TransitionVariant::Fade
+            }
+        }
+        _ => to.get_transition(),
+    }
+});
+use_context_provider(|| resolver);"#.to_string(),
+                        language: "rust".to_string(),
+                    }
+                }
+                p { class: "text-text-secondary mt-2",
+                    "This enables advanced navigation flows, such as card stacks, wizards, or any scenario where the transition direction depends on user action."
+                }
+            }
+
             // Navigation links
             GuideNavigation {}
         }

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -37,14 +37,21 @@ const MAIN_CSS: Asset = asset!("/assets/main.css");
 /// ```
 fn main() {
     dioxus::launch(|| {
-        let spring = use_signal(|| Spring {
-            stiffness: 220.0,
-            damping: 30.0,
-            mass: 1.0,
-            velocity: 0.0,
+        // To use a Tween for page transitions, provide it via context:
+        let tween = use_signal(|| Tween {
+            duration: std::time::Duration::from_millis(500),
+            easing: easer::functions::Cubic::ease_in_out,
         });
+        use_context_provider(|| tween);
 
-        use_context_provider(|| spring);
+        // To use a Spring instead, comment out the above and uncomment below:
+        // let spring = use_signal(|| Spring {
+        //     stiffness: 220.0,
+        //     damping: 30.0,
+        //     mass: 1.0,
+        //     velocity: 0.0,
+        // });
+        // use_context_provider(|| spring);
 
         rsx! {
             head {

--- a/docs/src/old_showcase/components/rotating_button.rs
+++ b/docs/src/old_showcase/components/rotating_button.rs
@@ -2,10 +2,13 @@ use dioxus::prelude::*;
 use dioxus_motion::{KeyframeAnimation, prelude::*};
 use easer::functions::Easing;
 
+// Add type alias for keyframe tuple
+type KeyframeTuple<T> = (T, f32, Option<fn(f32, f32, f32, f32) -> f32>);
+
 // Helper function to safely build keyframe animations
 fn build_keyframes<T: dioxus_motion::animations::core::Animatable>(
     duration: Duration,
-    keyframes: Vec<(T, f32, Option<fn(f32, f32, f32, f32) -> f32>)>,
+    keyframes: Vec<KeyframeTuple<T>>,
 ) -> Result<KeyframeAnimation<T>, dioxus_motion::keyframes::KeyframeError> {
     let mut animation = KeyframeAnimation::new(duration);
     for (value, offset, easing) in keyframes {

--- a/docs/src/old_showcase/components/rotating_button.rs
+++ b/docs/src/old_showcase/components/rotating_button.rs
@@ -2,13 +2,10 @@ use dioxus::prelude::*;
 use dioxus_motion::{KeyframeAnimation, prelude::*};
 use easer::functions::Easing;
 
-// Add type alias for keyframe tuple
-type KeyframeTuple<T> = (T, f32, Option<fn(f32, f32, f32, f32) -> f32>);
-
 // Helper function to safely build keyframe animations
 fn build_keyframes<T: dioxus_motion::animations::core::Animatable>(
     duration: Duration,
-    keyframes: Vec<KeyframeTuple<T>>,
+    keyframes: Vec<(T, f32, Option<fn(f32, f32, f32, f32) -> f32>)>,
 ) -> Result<KeyframeAnimation<T>, dioxus_motion::keyframes::KeyframeError> {
     let mut animation = KeyframeAnimation::new(duration);
     for (value, offset, easing) in keyframes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,8 @@ pub mod prelude {
     #[cfg(feature = "transitions")]
     pub use crate::transitions::config::TransitionVariant;
     #[cfg(feature = "transitions")]
+    pub use crate::transitions::page_transitions::TransitionVariantResolver;
+    #[cfg(feature = "transitions")]
     pub use crate::transitions::page_transitions::{AnimatableRoute, AnimatedOutlet};
     pub use crate::{AnimationManager, Duration, Time, TimeProvider, use_motion};
 }


### PR DESCRIPTION
Page transitions can now use either a Tween or Spring animation, depending on which is provided via context. The documentation and example usage in main.rs have been updated to show how to provide a Tween, with the Spring option commented for reference. The transition logic in page_transitions.rs now checks for a Tween in context and falls back to Spring if not found.

Fixes #50 #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic transition directions based on navigation context, allowing transitions like slide left, slide right, or fade depending on route order.
  * Introduced configurable animation modes for page transitions, supporting both tween and spring animations with customizable easing and durations.

* **Documentation**
  * Added a new section explaining dynamic transition direction in the page transitions guide, including usage examples and advanced navigation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->